### PR TITLE
Switch local development to use postgres within a docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# noCTF
+
+
+## Developing
+
+### Getting started
+
+```
+$ yarn install
+$ yarn workspace noctf-server run dev-setup
+$ docker-compose -f docker-compose.dev.yaml up --build
+```
+
+Goto https://localhost:3000/api/docs and ignore the SSL warnings. A certificate is present in `data/secrets/https` if you would like to install it.

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,34 @@
+version: '3'
+
+services:
+  postgres:
+    image: postgres
+    ports: [ 5432:5432 ]
+    environment:
+      POSTGRES_USER: noctf
+      POSTGRES_PASSWORD: devpassword
+      POSTGRES_DB: noctf
+    volumes:
+      - postgres:/var/lib/postgres/data/
+  redis:
+    image: redis
+    ports: [ 6379:6379 ]
+  noctf_server:
+    build:
+      context: ./pkg/server/
+      dockerfile: Dockerfile.dev
+    ports: [ 3000:3000 ]
+    environment:
+      NOCTF_SECRETS_DIR: /data/secrets
+      NOCTF_SECRETS_WATCH: "true"
+      NOCTF_REDIS_URL: redis://redis:6379/
+      NOCTF_DATABASE_CONNECTION_NAME: noctf
+      NOCTF_DATABASE_CONNECTION_HOST: postgres
+      NOCTF_DATABASE_CONNECTION_USERNAME: noctf
+      NOCTF_DATABASE_CONNECTION_PASSWORD: devpassword
+    volumes:
+      - ./pkg/server/:/srv/
+      - ./data:/data:ro
+
+volumes:
+  postgres:

--- a/pkg/server/Dockerfile.dev
+++ b/pkg/server/Dockerfile.dev
@@ -1,0 +1,9 @@
+FROM node
+
+WORKDIR /srv
+
+COPY ./ /srv/
+
+ENV NODE_ENV development
+
+CMD [ "sh", "-c", "npx knex migrate:up && npx tsc-watch --onSuccess \"node dist/src/\"" ]

--- a/pkg/server/dev-setup.ts
+++ b/pkg/server/dev-setup.ts
@@ -1,7 +1,7 @@
 import { generateKeyPair } from 'jose/util/generate_key_pair';
 import { exportJWK } from 'jose/key/export';
 import { createHash } from 'crypto';
-import { pki } from 'node-forge';
+import { pki, md } from 'node-forge';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -43,7 +43,7 @@ const generateCertificate = (keyFile: string, certFile: string) => {
       value: 'localhost'
     }
   ])
-  cert.sign(keys.privateKey);
+  cert.sign(keys.privateKey, md.sha256.create());
 
   const pubKey = pki.certificateToPem(cert);
   fs.writeFileSync(keyFile, privKey);

--- a/pkg/server/knexfile.ts
+++ b/pkg/server/knexfile.ts
@@ -2,9 +2,19 @@
 
 module.exports = {
   development: {
-    client: 'sqlite3',
+    client: 'postgresql',
     connection: {
-      filename: '../../data/noctf.db'
+      host:     process.env.NOCTF_DATABASE_CONNECTION_HOST || 'postgres',
+      database: process.env.NOCTF_DATABASE_CONNECTION_NAME || 'noctf',
+      user:     process.env.NOCTF_DATABASE_CONNECTION_USERNAME || 'noctf',
+      password: process.env.NOCTF_DATABASE_CONNECTION_PASSWORD || 'devpassword'
+    },
+    pool: {
+      min: 2,
+      max: 4
+    },
+    migrations: {
+      tableName: 'knex_migrations'
     }
   },
 

--- a/pkg/server/migrations/20211003110744_create_auth_tables.ts
+++ b/pkg/server/migrations/20211003110744_create_auth_tables.ts
@@ -10,7 +10,7 @@ export async function up(knex: Knex): Promise<void> {
       case 'mysql':
         return knex.raw('(UNIX_TIMESTAMP())');
       case 'postgresql':
-        return knex.raw('(epoch from now())');
+        return knex.raw('(extract(epoch from now()))');
       default:
         return knex.fn.now();
     }
@@ -46,7 +46,7 @@ export async function up(knex: Knex): Promise<void> {
   });
 
   await knex.schema.createTable('roles', (table) => {
-    table.integer('id').primary();
+    table.increments('id').primary();
     table.string('name', 48).unique().notNullable();
     table.bigInteger('created_at').notNullable().defaultTo(now);
   });

--- a/pkg/server/package.json
+++ b/pkg/server/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "dev": "NODE_ENV=development NOCTF_SECRETS_DIR='../../data/secrets' NOCTF_SECRETS_WATCH=true tsc-watch --onSuccess \"node dist/src/\"",
-    "dev-setup": "ts-node dev-setup.ts && knex migrate:up",
+    "dev-setup": "ts-node dev-setup.ts",
     "build": "tsc",
     "lint": "eslint --ext js,ts src/*",
     "fix-lint": "eslint --fix --ext js,ts src/"

--- a/pkg/server/src/config.ts
+++ b/pkg/server/src/config.ts
@@ -8,7 +8,6 @@ declare const process : {
     NOCTF_TOKEN_EXPIRY: string,
     NOCTF_DOCS_ENABLED: string,
     NOCTF_DATABASE_CLIENT: string,
-    NOCTF_DATABASE_CONNECTION_FILENAME: string,
     NOCTF_DATABASE_CONNECTION_NAME: string,
     NOCTF_DATABASE_CONNECTION_HOST: string,
     NOCTF_DATABASE_CONNECTION_USERNAME: string,
@@ -30,12 +29,11 @@ export const SECRETS_WATCH = (
   && process.env.NOCTF_SECRETS_WATCH !== 'false'
 );
 
-export const DATABASE_CLIENT = process.env.NOCTF_DATABASE_CLIENT || 'sqlite3';
+export const DATABASE_CLIENT = process.env.NOCTF_DATABASE_CLIENT || 'postgresql';
 export const DATABASE_CONNECTION = {
-  filename: process.env.NOCTF_DATABASE_CONNECTION_FILENAME || './data/noctf.db',
   database: process.env.NOCTF_DATABASE_CONNECTION_NAME,
   host: process.env.NOCTF_DATABASE_CONNECTION_HOST,
-  username: process.env.NOCTF_DATABASE_CONNECTION_USERNAME,
+  user: process.env.NOCTF_DATABASE_CONNECTION_USERNAME,
   password: process.env.NOCTF_DATABASE_CONNECTION_PASSWORD,
 };
 

--- a/pkg/server/src/models/User.ts
+++ b/pkg/server/src/models/User.ts
@@ -39,7 +39,7 @@ export class UserDAO {
       name,
       email: email.toLowerCase(),
       created_at,
-    });
+    }).returning('id');
 
     // Give user the default role
     await this.addRole(res[0], 'default');


### PR DESCRIPTION
Switch local dev to use postgres instead of sqlite, it means we can implement specific stuff like error handling - I'm not sure knex supports generic errors.

This isn't fully tested.