### PR TITLE
fix tag filtering

### DIFF
--- a/core/server-core/src/services/challenge.ts
+++ b/core/server-core/src/services/challenge.ts
@@ -317,7 +317,7 @@ export class ChallengeService {
       .filter((t) => !t.startsWith("noctf:"))
       .reduce(
         (p, v) => {
-          p[v] = v;
+          p[v] = tags[v];
           return p;
         },
         {} as Record<string, string>,


### PR DESCRIPTION
tag filtering behaviour was buggy and would previously transform a tag of `{"difficulty": "easy"}` into `{"difficulty": "difficulty"}`. this should fix