### PR TITLE
Add admin list challenges and get scoring strategies API

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -141,7 +141,7 @@ const logRequest = async (
   reply: { elapsedTime?: number; statusCode?: number },
   flag?: string,
 ) => {
-  const elapsed = reply.elapsedTime.toFixed(2);
+  const elapsed = +reply.elapsedTime.toFixed(2);
   server.log.info(
     {
       elapsed,

--- a/apps/server/src/routes/admin_challenge.ts
+++ b/apps/server/src/routes/admin_challenge.ts
@@ -5,14 +5,67 @@ import {
 } from "@noctf/api/requests";
 import {
   AdminGetChallengeResponse,
+  AdminGetScoringStrategiesResponse,
+  AdminListChallengesResponse,
   AdminUpdateChallengeResponse,
   AnyResponse,
 } from "@noctf/api/responses";
+import { FilterChallengesQuery } from "@noctf/api/query";
 import { ActorType } from "@noctf/server-core/types/enums";
 import type { FastifyInstance } from "fastify";
 
 export async function routes(fastify: FastifyInstance) {
-  const { challengeService } = fastify.container.cradle;
+  const { challengeService, scoreService } = fastify.container.cradle;
+
+  fastify.get<{
+    Reply: AdminGetScoringStrategiesResponse;
+  }>(
+    "/admin/scoring_strategies",
+    {
+      schema: {
+        tags: ["admin"],
+        security: [{ bearer: [] }],
+        auth: {
+          require: true,
+          policy: ["admin.challenge.get"],
+        },
+        response: {
+          200: AdminGetScoringStrategiesResponse,
+        },
+      },
+    },
+    async (request) => {
+      return {
+        data: await scoreService.getStrategies(),
+      };
+    },
+  );
+
+  fastify.get<{
+    Querystring: FilterChallengesQuery;
+    Reply: AdminListChallengesResponse;
+  }>(
+    "/admin/challenges",
+    {
+      schema: {
+        tags: ["admin"],
+        security: [{ bearer: [] }],
+        auth: {
+          require: true,
+          policy: ["admin.challenge.get"],
+        },
+        querystring: FilterChallengesQuery,
+        response: {
+          200: AdminListChallengesResponse,
+        },
+      },
+    },
+    async (request) => {
+      return {
+        data: await challengeService.list(request.query, false),
+      };
+    },
+  );
 
   fastify.post<{
     Body: AdminCreateChallengeRequest;

--- a/core/api/src/query.ts
+++ b/core/api/src/query.ts
@@ -1,0 +1,7 @@
+import { Static, Type } from "@sinclair/typebox";
+import { Challenge } from "./datatypes.ts";
+
+export const FilterChallengesQuery = Type.Partial(
+  Type.Pick(Challenge, ["tags", "hidden", "visible_at"]),
+);
+export type FilterChallengesQuery = Static<typeof FilterChallengesQuery>;

--- a/core/api/src/responses.ts
+++ b/core/api/src/responses.ts
@@ -10,6 +10,7 @@ import {
   ChallengeSolveStatus,
   Team,
   TypeDate,
+  ScoringStrategy,
 } from "./datatypes.ts";
 import { AuthRegisterToken, AuthTokenType } from "./token.ts";
 
@@ -125,6 +126,24 @@ export type AdminGetChallengeResponse = Static<
   typeof AdminGetChallengeResponse
 >;
 
+export const AdminListChallengesResponse = Type.Object({
+  data: Type.Array(
+    Type.Pick(Challenge, [
+      "id",
+      "slug",
+      "title",
+      "tags",
+      "hidden",
+      "visible_at",
+      "created_at",
+      "updated_at",
+    ]),
+  ),
+});
+export type AdminListChallengesResponse = Static<
+  typeof AdminListChallengesResponse
+>;
+
 export const AdminUpdateChallengeResponse = Type.Object({
   data: Type.Object({
     version: Type.Number(),
@@ -149,3 +168,11 @@ export const SolveChallengeResponse = Type.Object(
   { additionalProperties: false },
 );
 export type SolveChallengeResponse = Static<typeof SolveChallengeResponse>;
+
+export const AdminGetScoringStrategiesResponse = Type.Object(
+  { data: Type.Record(Type.String(), ScoringStrategy) },
+  { additionalProperties: false },
+);
+export type AdminGetScoringStrategiesResponse = Static<
+  typeof AdminGetScoringStrategiesResponse
+>;

--- a/core/server-core/src/services/score.ts
+++ b/core/server-core/src/services/score.ts
@@ -22,7 +22,7 @@ const STRATEGIES: Record<string, ScoringStrategy> = {
     expr: "max(base, (((base - top) / (decay ^ 2)) * (ctx.n ^ 2)) + top)",
     description:
       "Based on CTFd's dynamic scoring formula. base is the minimum score, top is the" +
-      "maximum score, and decay is the number of solves before the score becomes zero.",
+      " maximum score, and decay is the number of solves before the score becomes zero.",
   },
   exponential: {
     expr: "base + (top - base) / (1 + (max(0, ctx.n - 1)/k) ^ j)",
@@ -64,14 +64,14 @@ export class ScoreService {
     const strategies: Record<string, ScoringStrategy> = {};
     Object.keys(STRATEGIES).map(
       (k) =>
-        (strategies[k] = {
+        (strategies[`core:${k}`] = {
           ...STRATEGIES[k],
           source: "core",
         }),
     );
     Object.keys(cfgStrategies).map(
       (k) =>
-        (strategies[k] = {
+        (strategies[`config:${k}`] = {
           ...STRATEGIES[k],
           source: "config",
         }),


### PR DESCRIPTION
Add list challenges and get scoring strategies API. 
AdminListChallenges
```
{
  "data": [
    {
      "id": 1,
      "slug": "test-chal",
      "title": "test challenge",
      "tags": {},
      "hidden": false,
      "visible_at": null,
      "created_at": "2025-01-02T03:46:30.023Z",
      "updated_at": "2025-01-02T03:46:30.023Z"
    }
  ]
}
```

AdminListScoringStrategies
```
{
  "data": {
    "core:static": {
      "expr": "base",
      "description": "Returns a static score. Takes in a singular [base] param.",
      "source": "core"
    },
    "core:quadratic": {
      "expr": "max(base, (((base - top) / (decay ^ 2)) * (ctx.n ^ 2)) + top)",
      "description": "Based on CTFd's dynamic scoring formula. base is the minimum score, top is themaximum score, and decay is the number of solves before the score becomes zero.",
      "source": "core"
    },
    "core:exponential": {
      "expr": "base + (top - base) / (1 + (max(0, ctx.n - 1)/k) ^ j)",
      "description": "Based on the CCC CTF dynamic scoring formula. base is the minimum score, top is the maximum score, k is the scaling factor and j is the exponent.",
      "source": "core"
    }
  }
}
```