### PR TITLE
Backend: Scoreboard graph calculation

### DIFF
--- a/apps/server/src/routes/scoreboard.ts
+++ b/apps/server/src/routes/scoreboard.ts
@@ -40,7 +40,7 @@ export async function routes(fastify: FastifyInstance) {
     {
       schema: {
         security: [{ bearer: [] }],
-        tags: ["team"],
+        tags: ["scoreboard"],
         params: GetTeamParams,
         response: {
           200: ScoreboardTeamResponse,
@@ -65,6 +65,7 @@ export async function routes(fastify: FastifyInstance) {
         },
       );
       const scores = (await scoreboardService.getChallengeScores(1)).data;
+      const graph = await scoreboardService.getTeamGraph(request.params.id);
       const solves = challenges
         .map(({ id }) => {
           const s = scores[id]?.solves.find(
@@ -74,7 +75,7 @@ export async function routes(fastify: FastifyInstance) {
         })
         .filter((x) => x);
       return {
-        data: { solves },
+        data: { solves, graph },
       };
     },
   );

--- a/core/api/src/responses.ts
+++ b/core/api/src/responses.ts
@@ -206,6 +206,7 @@ export type ScoreboardResponse = Static<typeof ScoreboardResponse>;
 export const ScoreboardTeamResponse = Type.Object({
   data: Type.Object({
     solves: Type.Array(Solve),
+    graph: Type.Array(Type.Tuple([Type.Number(), Type.Number()])),
   }),
 });
 export type ScoreboardTeamResponse = Static<typeof ScoreboardTeamResponse>;

--- a/core/server-core/src/index.ts
+++ b/core/server-core/src/index.ts
@@ -17,7 +17,7 @@ import type { NATSClientFactory } from "./clients/nats.ts";
 import type { ChallengeService } from "./services/challenge/index.ts";
 import type { FileService } from "./services/file.ts";
 import type { ScoreService } from "./services/score.ts";
-import type { ScoreboardService } from "./services/scoreboard.ts";
+import type { ScoreboardService } from "./services/scoreboard/index.ts";
 
 export type ServiceCradle = {
   logger: Logger;

--- a/core/server-core/src/services/scoreboard/calc.ts
+++ b/core/server-core/src/services/scoreboard/calc.ts
@@ -6,7 +6,7 @@ import {
 } from "@noctf/api/datatypes";
 import { Expression } from "expr-eval";
 import { DBSolve } from "../../dao/solve.ts";
-import { deepEqual, partition } from "../../util/object.ts";
+import { partition } from "../../util/object.ts";
 import { EvaluateScoringExpression } from "../score.ts";
 import { Logger } from "../../types/primitives.ts";
 
@@ -164,7 +164,8 @@ export const GetChangedTeamScores = (
     map.set(entry.team_id, entry);
   }
   for (const entry of s2) {
-    if (!deepEqual(entry, map.get(entry.team_id))) {
+    const e2 = map.get(entry.team_id);
+    if (entry.score !== e2?.score) {
       output.push(entry);
     }
   }

--- a/core/server-core/src/services/scoreboard/graph.ts
+++ b/core/server-core/src/services/scoreboard/graph.ts
@@ -1,0 +1,50 @@
+import { ScoreboardEntry } from "@noctf/api/datatypes";
+import { ServiceCradle } from "../../index.ts";
+import { decode, encode } from "cbor2";
+
+type Props = Pick<ServiceCradle, "redisClientFactory">;
+
+export const TEAM_NAMESPACE = "core:svc:scoreboard_graph";
+export class ScoreboardGraphService {
+  private readonly redisClientFactory;
+
+  constructor({ redisClientFactory }: Props) {
+    this.redisClientFactory = redisClientFactory;
+  }
+
+  async getTeam(id: number): Promise<[number, number][]> {
+    const client = await this.redisClientFactory.getClient();
+    // probably dumb
+    const data = await client.lRange(
+      client.commandOptions({ returnBuffers: true }),
+      `${TEAM_NAMESPACE}:${id}`,
+      0,
+      Number.MAX_SAFE_INTEGER,
+    );
+    return data.map((x) => decode(x) as [number, number]);
+  }
+
+  async clearTeam(id: number) {
+    const client = await this.redisClientFactory.getClient();
+    await client.del(`${TEAM_NAMESPACE}:${id}`);
+  }
+
+  async commitDiff(entries: ScoreboardEntry[]) {
+    const client = await this.redisClientFactory.getClient();
+    const byTeam = new Map<number, Buffer[]>();
+    for (const { team_id, score, time } of entries) {
+      let team = byTeam.get(team_id);
+      if (!team) {
+        team = [];
+        byTeam.set(team_id, team);
+      }
+      const data = encode([time.getTime(), score] as [number, number]);
+      team.push(Buffer.from(data.buffer, data.byteOffset, data.byteLength));
+    }
+    await Promise.all(
+      byTeam.entries().map(async ([id, scores]) => {
+        await client.lPush(`${TEAM_NAMESPACE}:${id}`, scores);
+      }),
+    );
+  }
+}


### PR DESCRIPTION
Add scoreboard graph calculation.

The algorithm first takes the original scoreboard, performs a diff and then pushes to the team graph if the score or last solve time of the challenge or score has updated. This keeps everything snappy.

TODO
- If user moves division (isolated scoreboard) - we currently don't recalculate their graph

```
{
  "data": {
    "solves": [
      {
        "team_id": 1,
        "challenge_id": 1,
        "hidden": false,
        "score": 500,
        "created_at": "2025-02-17T11:03:43.350Z"
      }
    ],
    "graph": [
      [
        1739790223350,
        500
      ]
    ]
  }
}
```