### PR TITLE
Remove filenames from challenge metadata

### DIFF
--- a/apps/web/src/lib/components/challenges/ChallengeCreateEdit.svelte
+++ b/apps/web/src/lib/components/challenges/ChallengeCreateEdit.svelte
@@ -28,6 +28,7 @@
   export interface ExistingFile {
     filename: string;
     id: number;
+    is_attachment: boolean;
   }
 
   export interface ChallData {
@@ -184,7 +185,7 @@
         strategy: scoringType,
         params: scoringParams,
       },
-      files: {},
+      files: [],
     };
     const payload = {
       slug,
@@ -195,11 +196,10 @@
       tags: createTags(),
       private_metadata,
     };
-    let fileRefsToAdd: {
-      [k in string]: { id: number; is_attachment: boolean };
-    } = Object.fromEntries(
-      existingFiles.map((f) => [f.filename, { id: f.id, is_attachment: true }]),
-    );
+    let fileRefsToAdd = existingFiles.map((f) => ({
+      id: f.id,
+      is_attachment: true,
+    }));
 
     let challengeId, version;
 
@@ -263,8 +263,8 @@
           creationError = res.error.message;
           return;
         }
-        const { filename, id } = res.data.data;
-        fileRefsToAdd[filename] = { id, is_attachment: true };
+        const { id } = res.data.data;
+        fileRefsToAdd.push({ id, is_attachment: true });
       }
     }
 

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -120,8 +120,7 @@ export const ChallengePrivateMetadataBase = Type.Object(
       },
       { additionalProperties: false },
     ),
-    files: Type.Record(
-      Type.String(),
+    files: Type.Array(
       Type.Object(
         {
           id: Type.Number(),

--- a/core/server-core/src/services/file/index.ts
+++ b/core/server-core/src/services/file/index.ts
@@ -131,5 +131,3 @@ export class FileService {
     });
   }
 }
-
-

--- a/core/server-core/src/services/file/local.ts
+++ b/core/server-core/src/services/file/local.ts
@@ -4,7 +4,11 @@ import { readFile, unlink, writeFile } from "node:fs/promises";
 import { pipeline } from "node:stream/promises";
 import { type BinaryLike, createHmac } from "node:crypto";
 import { join } from "node:path";
-import { BadRequestError, ForbiddenError, NotFoundError } from "../../errors.ts";
+import {
+  BadRequestError,
+  ForbiddenError,
+  NotFoundError,
+} from "../../errors.ts";
 import { Readable } from "node:stream";
 import { nanoid } from "nanoid";
 import { FileMetadata } from "@noctf/api/datatypes";


### PR DESCRIPTION
Remove filenames from challenge metadata and instead load them as n+1 on server.

Should be fine as admin panel does not see heavy traffic.