### PR TITLE
[wip] Categorize Challenge Board

### DIFF
--- a/apps/web/src/lib/api/index.svelte.ts
+++ b/apps/web/src/lib/api/index.svelte.ts
@@ -23,15 +23,18 @@ client.use(authMiddleware);
 type Loadable<T> =
   | {
       loading: true;
+      error: undefined;
       r: undefined;
     }
   | {
       loading: false;
+      error: boolean;
       r: T;
     };
 export function wrapLoadable<T>(p: Promise<T>): Loadable<T> {
   const s = $state<Loadable<T>>({
     loading: true,
+    error: undefined,
     r: undefined,
   });
   p.then(
@@ -41,9 +44,12 @@ export function wrapLoadable<T>(p: Promise<T>): Loadable<T> {
     },
     (e) => {
       s.loading = false;
+      s.error = true;
       console.error(e);
     },
-  );
+  ).finally(() => {
+    s.loading = false;
+  });
   return s;
 }
 

--- a/apps/web/src/lib/components/challenges/ChallengeCard.svelte
+++ b/apps/web/src/lib/components/challenges/ChallengeCard.svelte
@@ -21,32 +21,33 @@
   import { type Difficulty } from "$lib/constants/difficulties";
 
   const { data, onclick }: ChallengeCardProps = $props();
-  const { title, categories, solves, points, isSolved, difficulty } = data;
+  // Cannot destructure data here, breaks reactivity https://svelte.dev/docs/svelte/$state#Deep-state
+  // const { title, categories, solves, points, isSolved, difficulty } = data;
 </script>
 
 <button
-  class={`text-left card w-60 h-32 pop ${isSolved ? "bg-primary text-primary-content" : "bg-base-100"} rounded-lg shadow-black`}
+  class={`text-left card w-60 h-32 pop ${data.isSolved ? "bg-primary text-primary-content" : "bg-base-100"} rounded-lg shadow-black`}
   onclick={() => onclick(data)}
 >
   <div class="card-body p-3 flex flex-col">
     <div class="card-title line-clamp-1 font-black">
-      {title}
+      {data.title}
     </div>
     <div class="flex flex-row items-center gap-3">
-      {#if difficulty}
+      {#if data.difficulty}
         <div
-          class={`badge badge-sm rounded-xl text-xs font-black border-base-content shadow-solid ${difficultyToBgColour(difficulty as Difficulty)}`}
+          class={`badge badge-sm rounded-xl text-xs font-black border-base-content shadow-solid ${difficultyToBgColour(data.difficulty as Difficulty)}`}
         >
-          {difficulty}
+          {data.difficulty}
         </div>
       {/if}
       <div
-        class={`${isSolved ? "bg-primary-content" : "bg-neutral-400"} w-full h-[1px]`}
+        class={`${data.isSolved ? "bg-primary-content" : "bg-neutral-400"} w-full h-[1px]`}
       ></div>
       <div
-        class={`self-center flex flex-row gap-1 text-2xl ${isSolved ? "text-primary-content" : "text-neutral-400"}`}
+        class={`self-center flex flex-row gap-1 text-2xl ${data.isSolved ? "text-primary-content" : "text-neutral-400"}`}
       >
-        {#each categories as cat}
+        {#each data.categories as cat}
           <div class="tooltip" data-tip={cat}>
             <Icon icon={categoryToIcon(cat)} />
           </div>
@@ -58,16 +59,16 @@
       <div class="flex flex-row justify-between">
         <div class="flex flex-row items-center gap-1 font-bold text-xl">
           <Icon icon="material-symbols:flag" class="text-3xl" />
-          {solves}
+          {data.solves}
         </div>
         <div class="flex flex-row items-center gap-1 font-bold text-xl">
           <Icon
-            icon={isSolved
+            icon={data.isSolved
               ? "material-symbols:check-circle-outline-rounded"
               : "material-symbols:stars-outline-rounded"}
             class="text-3xl"
           />
-          {points}
+          {data.points}
         </div>
       </div>
     </div>

--- a/apps/web/src/lib/constants/categories.ts
+++ b/apps/web/src/lib/constants/categories.ts
@@ -8,6 +8,7 @@ export const CATEGORIES = [
   "forensics",
   "osint",
   "blockchain",
+  "beginner",
 ] as const;
 export type Category = (typeof CATEGORIES)[number];
 export const ICON_MAP: { [k in Category | "all"]: string } = {
@@ -21,5 +22,6 @@ export const ICON_MAP: { [k in Category | "all"]: string } = {
   forensics: "material-symbols:document-search-rounded",
   osint: "ph:detective-fill",
   blockchain: "tdesign:blockchain",
+  beginner: "mdi:seedling",
 };
 export const CATEGORY_UNKNOWN_ICON = "carbon:unknown-filled";

--- a/apps/web/src/lib/utils/challenges.ts
+++ b/apps/web/src/lib/utils/challenges.ts
@@ -25,7 +25,8 @@ export const getDifficultyFromTags = (tags: { [k in string]: string }) => {
 };
 
 export const getCategoriesFromTags = (tags: { [k in string]: string }) => {
-  return tags?.["categories"]?.split(",") ?? [];
+  const categories = tags?.["categories"];
+  return categories ? categories?.split(",") : ["uncategorized"];
 };
 
 export const slugify = (title: string) => {

--- a/apps/web/src/routes/challenges/+page.svelte
+++ b/apps/web/src/routes/challenges/+page.svelte
@@ -54,6 +54,43 @@
 
   let challenges: ChallengeCardData[] | undefined = $state();
 
+  let challengesByCategory = $derived.by(() => {
+    if (!challenges) {
+      return {}; // Return empty object if no filtered challenges
+    }
+
+    const grouped: { [category: string]: ChallengeCardData[] } = {};
+
+    for (const challenge of challenges) {
+      // If a challenge has no categories, maybe put it in an "Uncategorized" group
+      const categories =
+        challenge.categories.length > 0
+          ? challenge.categories
+          : ["uncategorized"];
+
+      for (const category of categories) {
+        if (!grouped[category]) {
+          grouped[category] = [];
+        }
+        grouped[category].push(challenge);
+      }
+    }
+
+    // Sort challenges within each category by points (ascending)
+    for (const category in grouped) {
+      grouped[category]!.sort((a, b) => (a.points || 0) - (b.points || 0));
+    }
+
+    // Sort categories alphabetically by name
+    const sortedCategories = Object.keys(grouped).sort();
+    const sortedGrouped: { [category: string]: ChallengeCardData[] } = {};
+    for (const category of sortedCategories) {
+      sortedGrouped[category] = grouped[category] || [];
+    }
+
+    return sortedGrouped;
+  });
+
   let modalVisible = $state(false);
   let modalLoading = $state(false);
   let modalChallData: ChallengeCardData | undefined = $state();
@@ -119,10 +156,19 @@
       <div class="loading loading-spinner loading-lg text-primary"></div>
       <p class="text-center">Loading challenges...</p>
     </div>
-  {:else if apiChallenges.r.error}
+  {:else if apiChallenges.error || apiChallenges.r?.error}
     <div class="flex flex-col items-center gap-4 mt-16">
-      <p class="text-center">{apiChallenges.r.error.message}</p>
-      <button class="btn btn-primary" onclick={refreshChallenges}>
+      <p class="text-center">
+        {apiChallenges.r?.error?.message || "Unknown error occurred"}
+      </p>
+      <button
+        class="btn btn-primary"
+        onclick={() => {
+          // Refresh challenges does not reset the loading state
+          // so we need to reset it manually
+          apiChallenges = wrapLoadable(api.GET("/challenges"));
+        }}
+      >
         Retry
       </button>
     </div>
@@ -137,20 +183,32 @@
         />
       </div>
 
-      <div
-        class="flex flex-row flex-wrap gap-4 justify-center md:justify-start content-start"
-      >
-        {#if challenges && challenges.length > 0}
-          {#each challenges as challenge (challenge)}
-            <ChallengeCard data={challenge} onclick={onChallengeClicked} />
+      <div class="flex flex-wrap gap-6">
+        {#if challenges !== undefined && Object.keys(challengesByCategory).length > 0}
+          {#each Object.entries(challengesByCategory) as [category, categoryChallenges] (category)}
+            <div class="">
+              <h2 class="text-xl w-min p-3 rounded font-bold top-0 py-2 z-10">
+                {category}
+              </h2>
+              <div
+                class="flex flex-wrap md:justify-start justify-center pt-2 gap-4 min-w-[150px]"
+              >
+                {#each categoryChallenges as challenge (challenge.id)}
+                  <ChallengeCard
+                    data={challenge}
+                    onclick={onChallengeClicked}
+                  />
+                {/each}
+              </div>
+            </div>
           {/each}
-        {:else if allChallenges && challenges && challenges.length === 0}
-          <p class="w-full text-center text-neutral-500">
+        {:else if challenges !== undefined && challenges.length === 0}
+          <p class="w-full text-center text-neutral-500 py-10">
             No challenges match the current filters.
           </p>
-        {:else if !allChallenges}
-          <p class="w-full text-center text-neutral-500">
-            Challenges loaded incorrectly.
+        {:else if challenges === undefined && !apiChallenges.loading}
+          <p class="w-full text-center text-neutral-500 py-10">
+            Waiting for challenges...
           </p>
         {/if}
       </div>


### PR DESCRIPTION
Add beginner Icon category 

fix reactivity of challenge cards, TIL you can't destructure state in svelte.

Added an error state to the Loadable type to determine failure to fix some error handling

organise challenge board by category. I think there is a better way to do this since the filterer already does sorting by category, so this might be duplicating work. 