### PR TITLE
handle scoreboard teams endpoint 404 on frontend

### DIFF
--- a/apps/server/src/routes/scoreboard.ts
+++ b/apps/server/src/routes/scoreboard.ts
@@ -132,6 +132,9 @@ export async function routes(fastify: FastifyInstance) {
         throw new NotFoundError("Team not found");
       }
       const entry = await scoreboardService.getTeam(team.division_id, team.id);
+      if (!entry) {
+        throw new NotFoundError("Team not found");
+      }
       if (request.query.tags) {
         const rank = await scoreboardService.getTeamRank(
           team.division_id,
@@ -146,9 +149,6 @@ export async function routes(fastify: FastifyInstance) {
       const graph = await scoreboardService.getTeamScoreHistory(
         request.params.id,
       );
-      if (!entry) {
-        throw new NotFoundError("Team not found");
-      }
       const solves = entry.solves.filter(({ hidden }) => !hidden);
       return {
         data: {

--- a/apps/web/src/routes/scoreboard/+page.svelte
+++ b/apps/web/src/routes/scoreboard/+page.svelte
@@ -13,9 +13,9 @@
 
   type ScoreboardEntry = {
     team_id: number;
-    rank: number;
+    rank?: number;
     score: number;
-    last_solve: Date;
+    last_solve?: Date;
     solves: {
       value: number;
       bonus?: number;
@@ -123,6 +123,20 @@
   );
 
   const myTeamEntry = $derived.by(() => {
+    if (
+      !apiMyTeam?.r?.data?.data &&
+      authState.user?.team_id &&
+      !isMyTeamInCurrentPage
+    )
+      return {
+        team_id: authState.user.team_id,
+        rank: undefined,
+        score: 0,
+        last_solve: undefined,
+        solves: [],
+        awards: [],
+      };
+
     if (!apiMyTeam?.r?.data?.data) return null;
 
     const teamData = apiMyTeam.r.data.data;
@@ -147,7 +161,7 @@
       return apiTeams;
     }
 
-    return myTeamEntry.rank < apiTeams[0]!.rank
+    return myTeamEntry.rank && myTeamEntry.rank < apiTeams[0]!.rank
       ? [myTeamEntry, ...apiTeams]
       : [...apiTeams, myTeamEntry];
   });
@@ -236,8 +250,10 @@
   </div>
 {/snippet}
 
-{#snippet rankDisplay(rank: number)}
-  {#if rank <= 3}
+{#snippet rankDisplay(rank?: number)}
+  {#if rank === undefined}
+    <span class="font-mono">-</span>
+  {:else if rank <= 3}
     <span class="text-xl">{["🥇", "🥈", "🥉"][rank - 1]}</span>
   {:else}
     <span class="font-mono">{rank}</span>
@@ -440,7 +456,7 @@
             </td>
             <td
               class="border border-base-300 py-2 px-3 text-center"
-              title={entry.last_solve.toLocaleString()}
+              title={entry?.last_solve ? entry.last_solve.toLocaleString() : ""}
             >
               {entry.last_solve?.getTime()
                 ? getRelativeTime(entry.last_solve)
@@ -662,7 +678,9 @@
                     </td>
                     <td
                       class="border border-base-300 py-2 px-3 text-center text-sm min-w-32 max-w-32"
-                      title={entry.last_solve.toLocaleString()}
+                      title={entry?.last_solve
+                        ? entry.last_solve.toLocaleString()
+                        : ""}
                     >
                       {entry.last_solve?.getTime()
                         ? getRelativeTime(entry.last_solve)

--- a/apps/web/src/routes/teams/[id]/page.svelte
+++ b/apps/web/src/routes/teams/[id]/page.svelte
@@ -72,7 +72,22 @@
 
   const teamTags = $derived(teamTagsLoader.r?.data?.data?.tags || []);
 
-  let scoreboardData = $derived(scoreboardLoader.r?.data?.data);
+  let scoreboardData = $derived.by(() => {
+    if (scoreboardLoader.loading || !team) return undefined;
+    const data = scoreboardLoader.r?.data?.data;
+    return (
+      data || {
+        team_id: team?.id,
+        tag_ids: team?.tag_ids,
+        score: undefined,
+        rank: undefined,
+        last_solve: undefined,
+        solves: [],
+        awards: [],
+        graph: undefined,
+      }
+    );
+  });
   const challenges: ChallengeEntry[] | undefined = $derived(
     challengesLoader.r?.data?.data.challenges
       .map((c) => ({
@@ -343,9 +358,9 @@
             <div class="w-32"></div>
           {/if}
         </div>
-        {#if scoreboardData && teamTags}
+        {#if team && teamTags}
           <div class="flex flex-row gap-2">
-            {#each scoreboardData.tag_ids as tag_id}
+            {#each team.tag_ids as tag_id}
               {@const tag = teamTags.find((t) => t.id === tag_id)}
               {#if tag}
                 <div class="p-1 px-4 pop bg-secondary/40 rounded-lg">
@@ -358,7 +373,7 @@
         <div class="flex flex-col gap-4">
           {#if scoreboardLoader.loading && !scoreboardData}
             <div class="skeleton h-4 w-1/2"></div>
-          {:else if scoreboardData}
+          {:else if scoreboardData?.rank && scoreboardData?.score}
             <div
               class="text-3xl font-black pop bg-primary text-primary-content p-1 px-4 rounded-xl"
             >
@@ -397,7 +412,7 @@
               {@render emptySolves()}
             {/if}
 
-            {#if scoreboardData}
+            {#if scoreboardData?.graph}
               <Graph data={[{ name: team.name, data: scoreboardData.graph }]} />
             {/if}
           {/if}

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -51,6 +51,7 @@ export const Team = Type.Object({
     Type.String({ minLength: 2, maxLength: 2 }),
     Type.Null(),
   ]),
+  tag_ids: Type.Array(Type.Integer()),
   join_code: Type.Union([Type.String({ maxLength: 64 }), Type.Null()]),
   division_id: Type.Number(),
   flags: Type.Array(Type.String()),


### PR DESCRIPTION
resolves #140 

behaviour is to show the team in the scoreboard but with - in rank and 0 for score/solves. team page no longer errors for teams with no activity and just shows what can be shown