### PR TITLE
Validate email in reset_password

### DIFF
--- a/core/mod-auth/src/password_routes.ts
+++ b/core/mod-auth/src/password_routes.ts
@@ -284,6 +284,7 @@ export default async function (fastify: FastifyInstance) {
         if (e instanceof AuthenticationError) {
           throw new AuthenticationError("Incorrect password");
         }
+        throw e;
       }
 
       const newEmail = request.body.email?.toLowerCase();


### PR DESCRIPTION
- Validate email in reset password since the token can only originate from an email.
- Fix auth message
