### PR TITLE
Improve the rate limit algorithm

### DIFF
--- a/core/server-core/src/services/rate_limit.test.ts
+++ b/core/server-core/src/services/rate_limit.test.ts
@@ -38,171 +38,431 @@ describe(RateLimitService, () => {
     vi.resetAllMocks();
   });
 
-  it("should return null when not rate limited", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 10 },
-    ];
+  describe(RateLimitService.prototype.evaluate, () => {
+    it("should return null when not rate limited", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 10 },
+      ];
 
-    mockRedisClient.mGet.mockResolvedValueOnce(["5", "2"]);
+      mockRedisClient.mGet.mockResolvedValueOnce(["5", "2"]);
 
-    const result = await service.evaluate(buckets);
+      const result = await service.evaluate(buckets);
 
-    expect(result).toBeNull();
-    expect(mockRedisClient.mGet).toHaveBeenCalledWith([
-      "core:rl:bucket:900:60:test",
-      "core:rl:bucket:960:60:test",
-    ]);
+      expect(result).toBeNull();
+      expect(mockRedisClient.mGet).toHaveBeenCalledWith([
+        "core:rl:bucket:900:60:test",
+        "core:rl:bucket:960:60:test",
+      ]);
+    });
+
+    it("should return block time when rate limited", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 10 },
+      ];
+
+      mockRedisClient.mGet.mockResolvedValueOnce(["5", "8"]);
+
+      const result = await service.evaluate(buckets);
+
+      expect(result).not.toBeNull();
+      expect(typeof result).toBe("number");
+    });
+
+    it("should return blocked time from cache if already blocked", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 10 },
+      ];
+
+      const blocked = service["blocked"] as TTLCache<string, number>;
+      vi.mocked(blocked.getRemainingTTL).mockReturnValueOnce(1030);
+
+      const result = await service.evaluate(buckets);
+
+      expect(result).toBe(1030);
+      expect(mockRedisClient.mGet).not.toHaveBeenCalled();
+    });
+
+    it("should batch writes to Redis", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test1", windowSeconds: 60, limit: 100 },
+        { key: "test2", windowSeconds: 120, limit: 200 },
+      ];
+
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0", "0", "0"]);
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
+
+      // First request
+      await service.evaluate(buckets);
+
+      // Advance time to trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
+
+      expect(mockRedisClient.multi).toHaveBeenCalled();
+      expect(mockRedisClient.multi().incrBy).toHaveBeenCalledTimes(2);
+      expect(mockRedisClient.multi().expireAt).toHaveBeenCalledTimes(2);
+      expect(mockRedisClient.multi().exec).toHaveBeenCalled();
+    });
+
+    it("should handle Redis errors gracefully", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
+
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockRejectedValue(new Error("Redis error")),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
+      const promise = Promise.withResolvers<void>();
+      vi.mocked(mockLogger.error).mockImplementation(() => promise.resolve());
+
+      // First request
+      await service.evaluate(buckets);
+
+      // Advance time to trigger dump
+      vi.advanceTimersByTime(25);
+      await promise.promise;
+      expect(mockLogger.error).toHaveBeenCalled();
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      const result = await service.evaluate(buckets);
+      expect(result).toBeNull();
+    });
+
+    it("should reuse fetch results when multiple buckets request the same keys", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+        { key: "test", windowSeconds: 60, limit: 50 },
+      ];
+
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+
+      await service.evaluate(buckets);
+
+      expect(mockRedisClient.mGet).toHaveBeenCalledTimes(1);
+    });
+
+    it("should handle concurrent requests with fetch locks", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
+
+      const delayed = Promise.withResolvers<(string | null)[]>();
+
+      mockRedisClient.mGet.mockReturnValueOnce(delayed.promise);
+
+      // Start two concurrent evaluations
+      const promise1 = service.evaluate(buckets);
+      const promise2 = service.evaluate(buckets);
+
+      // Resolve the Redis call
+      delayed.resolve(["0", "0"]);
+
+      const [result1, result2] = await Promise.all([promise1, promise2]);
+
+      expect(mockRedisClient.mGet).toHaveBeenCalledTimes(1);
+      expect(result1).toBeNull();
+      expect(result2).toBeNull();
+    });
+
+    it("if fetch fails then throw error and release locks", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
+
+      mockRedisClient.mGet.mockRejectedValueOnce(new Error("Redis error"));
+
+      // Start two concurrent evaluations
+      const promise1 = service.evaluate(buckets);
+      const promise2 = service.evaluate(buckets);
+
+      await expect(Promise.all([promise1, promise2])).rejects.toThrowError();
+    });
+
+    it("should calculate correct rate limit estimate", async () => {
+      // Testing with values that would trigger a rate limit
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 10 },
+      ];
+
+      // Set current time to 30 seconds into the window
+      vi.setSystemTime(new Date(1030 * 1000));
+
+      // Previous window had 10 requests, current has 5
+      mockRedisClient.mGet.mockResolvedValueOnce(["10", "5"]);
+
+      const result = await service.evaluate(buckets);
+
+      // This should be rate limited due to the estimate
+      expect(result).not.toBeNull();
+      expect(typeof result).toBe("number");
+    });
   });
 
-  it("should return block time when rate limited", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 10 },
-    ];
+  describe(RateLimitService.prototype.refund, () => {
+    it("should refund requests in the current window", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
 
-    mockRedisClient.mGet.mockResolvedValueOnce(["5", "8"]);
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
 
-    const result = await service.evaluate(buckets);
+      // Set up initial state by making a request
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      await service.evaluate(buckets);
 
-    expect(result).not.toBeNull();
-    expect(typeof result).toBe("number");
-  });
+      // Refund the request using the same timestamp
+      const refundTime = 1000 * 1000; // Same as the current time
+      await service.refund(refundTime, buckets);
 
-  it("should return blocked time from cache if already blocked", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 10 },
-    ];
+      // Trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
 
-    const blocked = service["blocked"] as TTLCache<string, number>;
-    vi.mocked(blocked.getRemainingTTL).mockReturnValueOnce(1030);
+      // The refund should have decremented the current window counter
+      // So no increment should be written to Redis
+      expect(mockRedisClient.multi().incrBy).not.toHaveBeenCalled();
+    });
 
-    const result = await service.evaluate(buckets);
+    it("should refund requests in the previous window", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
 
-    expect(result).toBe(1030);
-    expect(mockRedisClient.mGet).not.toHaveBeenCalled();
-  });
+      // Current time is 1000 seconds (window 960-1020)
+      // Previous window would be 900-960
+      const previousWindowTime = 950 * 1000; // 950 seconds = previous window
 
-  it("should batch writes to Redis", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test1", windowSeconds: 60, limit: 100 },
-      { key: "test2", windowSeconds: 120, limit: 200 },
-    ];
+      // Make a request first to establish state
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      await service.evaluate(buckets);
 
-    mockRedisClient.mGet.mockResolvedValueOnce(["0", "0", "0", "0"]);
-    mockRedisClient.multi.mockReturnValue({
-      incrBy: vi.fn().mockReturnThis(),
-      expireAt: vi.fn().mockReturnThis(),
-      exec: vi.fn().mockResolvedValue([]),
-    } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
-      typeof mockRedisClient.multi
-    >);
+      // Now refund a request from the previous window
+      await service.refund(previousWindowTime, buckets);
 
-    // First request
-    await service.evaluate(buckets);
+      // Set up mock for the dump
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
 
-    // Advance time to trigger dump
-    vi.advanceTimersByTime(25);
-    await Promise.resolve();
+      // Trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
 
-    expect(mockRedisClient.multi).toHaveBeenCalled();
-    expect(mockRedisClient.multi().incrBy).toHaveBeenCalledTimes(2);
-    expect(mockRedisClient.multi().expireAt).toHaveBeenCalledTimes(2);
-    expect(mockRedisClient.multi().exec).toHaveBeenCalled();
-  });
+      // Should have written the current window increment but decremented previous
+      expect(mockRedisClient.multi().incrBy).toHaveBeenCalledWith(
+        "core:rl:bucket:960:60:test",
+        1,
+      );
+    });
 
-  it("should handle Redis errors gracefully", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 100 },
-    ];
+    it("should refund requests in the next window", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
 
-    mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
-    mockRedisClient.multi.mockReturnValue({
-      incrBy: vi.fn().mockReturnThis(),
-      expireAt: vi.fn().mockReturnThis(),
-      exec: vi.fn().mockRejectedValue(new Error("Redis error")),
-    } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
-      typeof mockRedisClient.multi
-    >);
-    const promise = Promise.withResolvers<void>();
-    vi.mocked(mockLogger.error).mockImplementation(() => promise.resolve());
+      // Current time is 1000 seconds (window 960-1020)
+      // Next window would be 1020-1080
+      const nextWindowTime = 1050 * 1000; // 1050 seconds = next window
 
-    // First request
-    await service.evaluate(buckets);
+      // Make a request first
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      await service.evaluate(buckets);
 
-    // Advance time to trigger dump
-    vi.advanceTimersByTime(25);
-    await promise.promise;
-    expect(mockLogger.error).toHaveBeenCalled();
-    mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
-    const result = await service.evaluate(buckets);
-    expect(result).toBeNull();
-  });
+      // Refund a request from the next window
+      await service.refund(nextWindowTime, buckets);
 
-  it("should reuse fetch results when multiple buckets request the same keys", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 100 },
-      { key: "test", windowSeconds: 60, limit: 50 },
-    ];
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
 
-    mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      // Trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
 
-    await service.evaluate(buckets);
+      // Should have written the current window increment
+      expect(mockRedisClient.multi().incrBy).toHaveBeenCalledWith(
+        "core:rl:bucket:960:60:test",
+        1,
+      );
+    });
 
-    expect(mockRedisClient.mGet).toHaveBeenCalledTimes(1);
-  });
+    it("should handle refund for non-existent write entry", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "newkey", windowSeconds: 60, limit: 100 },
+      ];
 
-  it("should handle concurrent requests with fetch locks", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 100 },
-    ];
+      // Refund without any prior evaluate call
+      const refundTime = 1000 * 1000;
+      await service.refund(refundTime, buckets);
 
-    const delayed = Promise.withResolvers<(string | null)[]>();
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
 
-    mockRedisClient.mGet.mockReturnValueOnce(delayed.promise);
+      // Trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
 
-    // Start two concurrent evaluations
-    const promise1 = service.evaluate(buckets);
-    const promise2 = service.evaluate(buckets);
+      // Write a -1 as the key probably got removed from memory
+      expect(mockRedisClient.multi().incrBy).toHaveBeenCalledWith(
+        "core:rl:bucket:960:60:newkey",
+        -1,
+      );
+    });
 
-    // Resolve the Redis call
-    delayed.resolve(["0", "0"]);
+    it("should handle multiple refunds for the same bucket", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
 
-    const [result1, result2] = await Promise.all([promise1, promise2]);
+      // Make multiple requests first
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      await service.evaluate(buckets);
 
-    expect(mockRedisClient.mGet).toHaveBeenCalledTimes(1);
-    expect(result1).toBeNull();
-    expect(result2).toBeNull();
-  });
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "1"]);
+      await service.evaluate(buckets);
 
-  it("if fetch fails then throw error and release locks", async () => {
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 100 },
-    ];
+      // Refund both requests
+      const refundTime = 1000 * 1000;
+      await service.refund(refundTime, buckets);
+      await service.refund(refundTime, buckets);
 
-    mockRedisClient.mGet.mockRejectedValueOnce(new Error("Redis error"));
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
 
-    // Start two concurrent evaluations
-    const promise1 = service.evaluate(buckets);
-    const promise2 = service.evaluate(buckets);
+      // Trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
 
-    await expect(Promise.all([promise1, promise2])).rejects.toThrowError();
-  });
+      // Should not increment anything since both requests were refunded
+      expect(mockRedisClient.multi().incrBy).not.toHaveBeenCalled();
+    });
 
-  it("should calculate correct rate limit estimate", async () => {
-    // Testing with values that would trigger a rate limit
-    const buckets: RateLimitBucket[] = [
-      { key: "test", windowSeconds: 60, limit: 10 },
-    ];
+    it("should handle refunds for multiple buckets with different windows", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test1", windowSeconds: 60, limit: 100 },
+        { key: "test2", windowSeconds: 120, limit: 200 },
+      ];
 
-    // Set current time to 30 seconds into the window
-    vi.setSystemTime(new Date(1030 * 1000));
+      // Make requests for both buckets
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0", "0", "0"]);
+      await service.evaluate(buckets);
+      await service.evaluate(buckets);
 
-    // Previous window had 10 requests, current has 5
-    mockRedisClient.mGet.mockResolvedValueOnce(["10", "5"]);
+      // Refund both
+      const refundTime = 1000 * 1000;
+      await service.refund(refundTime, buckets);
 
-    const result = await service.evaluate(buckets);
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
 
-    // This should be rate limited due to the estimate
-    expect(result).not.toBeNull();
-    expect(typeof result).toBe("number");
+      // Trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
+
+      // Neither bucket should have increments since both were refunded
+      expect(mockRedisClient.multi().incrBy).toHaveBeenCalledWith(
+        "core:rl:bucket:960:60:test1",
+        1,
+      );
+      expect(mockRedisClient.multi().incrBy).toHaveBeenCalledWith(
+        "core:rl:bucket:960:120:test2",
+        1,
+      );
+    });
+
+    it("should ignore refunds for windows outside the tracking range", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
+
+      // Make a request first
+      mockRedisClient.mGet.mockResolvedValueOnce(["0", "0"]);
+      await service.evaluate(buckets);
+
+      // Try to refund from a window that's too far in the past
+      const oldWindowTime = 800 * 1000; // Way before current window
+      await service.refund(oldWindowTime, buckets);
+
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
+
+      // Trigger dump
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
+
+      // Should still increment the current window since refund was ignored
+      expect(mockRedisClient.multi().incrBy).toHaveBeenCalledWith(
+        "core:rl:bucket:960:60:test",
+        1,
+      );
+    });
+
+    it("should schedule dump timeout when refund is called", async () => {
+      const buckets: RateLimitBucket[] = [
+        { key: "test", windowSeconds: 60, limit: 100 },
+      ];
+
+      const refundTime = 1000 * 1000;
+      await service.refund(refundTime, buckets);
+
+      // Verify that timeout is set by checking if dump occurs
+      mockRedisClient.multi.mockReturnValue({
+        incrBy: vi.fn().mockReturnThis(),
+        expireAt: vi.fn().mockReturnThis(),
+        exec: vi.fn().mockResolvedValue([]),
+      } as Partial<ReturnType<typeof mockRedisClient.multi>> as ReturnType<
+        typeof mockRedisClient.multi
+      >);
+
+      vi.advanceTimersByTime(25);
+      await Promise.resolve();
+
+      // Even though no increments were made, the multi should be called due to the timeout
+      expect(mockRedisClient.multi).toHaveBeenCalled();
+    });
   });
 });

--- a/core/server-core/src/services/rate_limit.ts
+++ b/core/server-core/src/services/rate_limit.ts
@@ -1,10 +1,14 @@
 import TTLCache from "@isaacs/ttlcache";
 import { ServiceCradle } from "../index.ts";
+import { RedisClientFactory } from "../clients/redis.ts";
 
 type Props = Pick<ServiceCradle, "redisClientFactory" | "logger">;
 
 const FLUSH_INTERVAL_MS = 0;
 const BUCKET_NAMESPACE = "core:rl:bucket";
+
+type ReadTuple = [number, number, number];
+type WriteTuple = [number, number, number, number];
 
 export type RateLimitBucket = {
   key: string;
@@ -16,11 +20,11 @@ const EmptyFn = () => {};
 export class RateLimitService {
   // cache key
   // sample_window:key
-  private writes = new Map<string, number>();
+  private writes = new Map<string, WriteTuple>();
   private timeout: ReturnType<typeof setTimeout> | null;
-  private fetchLocks = new Map<string, Promise<[number, number]>>();
+  private fetchLocks = new Map<string, Promise<ReadTuple>>();
 
-  private readonly reads = new Map<string, [number, number]>();
+  private readonly reads = new Map<string, ReadTuple>();
   private readonly blocked = new TTLCache({
     max: 10000,
     ttl: 60000,
@@ -34,10 +38,14 @@ export class RateLimitService {
     this.logger = logger;
   }
 
+  /**
+   * Evaluate a rate limit request. If successful, then atomically increment all requested keys. If
+   * unsuccessful, return the next eligible window without incrementing counters.
+   *
+   * @param input buckets
+   * @returns null if successful or next eligible time
+   */
   async evaluate(input: RateLimitBucket[]): Promise<number | null> {
-    if (!this.timeout) {
-      this.timeout = setTimeout(() => this._dump(), FLUSH_INTERVAL_MS);
-    }
     const now = Math.floor(Date.now() / 1000);
     const buckets: RateLimitBucket[] = input.map(
       ({ key, windowSeconds, limit }) => ({
@@ -51,27 +59,38 @@ export class RateLimitService {
       const blocked = this.blocked.getRemainingTTL(key);
       if (blocked) maxBlocked = Math.max(maxBlocked, blocked);
     }
-    if (maxBlocked) return maxBlocked;
+    if (maxBlocked) {
+      return maxBlocked;
+    }
 
     const data = await this._read(now, buckets);
+    // since it's after all the await points then we do the cleanup
+    if (!this.timeout) {
+      this.timeout = setTimeout(() => this._dump(), FLUSH_INTERVAL_MS);
+    }
 
     maxBlocked = 0;
     for (const [i, { key, windowSeconds, limit }] of buckets.entries()) {
+      const currentWindow = Math.floor(now / windowSeconds) * windowSeconds;
       const read = data[i];
-      const write = this.writes.get(key) || 0;
+      let write = this.writes.get(key);
+      if (!write) {
+        write = [currentWindow, 0, 0, 0];
+        this.writes.set(key, write);
+      }
       // assume constant rate of requests in prev window
       // the request rate is equal number of requests in the current minute
       // plus an interpolated number of requests in the last minute using
       // linear decay (i.e. if we have 60 requests per min)
-      const current = read[1] + write;
+      const [_, prev, current] = AddWritesToRead(read, write, windowSeconds);
       const estimate =
-        (read[0] * (windowSeconds - (now % windowSeconds))) / windowSeconds +
+        (prev * (windowSeconds - (now % windowSeconds))) / windowSeconds +
         current +
         1;
       if (estimate >= limit) {
         const diff = estimate - limit;
         const ttl = Math.floor(
-          Math.min(diff / read[0], 1) *
+          Math.min(diff / prev, 1) *
             (windowSeconds - (now % windowSeconds)) *
             1000,
         );
@@ -82,51 +101,90 @@ export class RateLimitService {
       }
     }
     if (maxBlocked) return maxBlocked;
-    for (const { key } of buckets) {
-      this.writes.set(key, (this.writes.get(key) || 0) + 1);
+    for (const { key, windowSeconds } of buckets) {
+      const currentWindow = Math.floor(now / windowSeconds) * windowSeconds;
+      const write = this.writes.get(key)!; // this always exists since it's set above
+      if (write[0] === currentWindow) write[2]++;
+      else if (write[0] > currentWindow) write[3]++;
+      else if (write[0] < currentWindow) write[1]++;
     }
 
     return null;
   }
 
+  /**
+   * Refund a rate limit increment. The assumption is that the refund is enacted on the same node
+   * as the evaluation (monotonic time) so we should not hit a negative situation. If the sample
+   * window has passed, then refund should no longer be possible. This method is not atomic across
+   * different buckets.
+   *
+   * @param ts_ms timestamp of evaluate request
+   * @param input buckets to refund
+   */
+  async refund(ts_ms: number, input: RateLimitBucket[]): Promise<void> {
+    const buckets: RateLimitBucket[] = input.map(
+      ({ key, windowSeconds, limit }) => ({
+        key: `${windowSeconds}:${key}`,
+        windowSeconds,
+        limit,
+      }),
+    );
+    for (const { key, windowSeconds } of buckets) {
+      const refundWindow =
+        Math.floor(ts_ms / (1000 * windowSeconds)) * windowSeconds;
+      // We only want to refund if it's in the
+      let write = this.writes.get(key);
+      if (!write) {
+        const currentWindow =
+          Math.floor(Date.now() / (1000 * windowSeconds)) * windowSeconds;
+        write = [currentWindow, 0, 0, 0];
+        this.writes.set(key, write);
+      }
+      if (refundWindow === write[0]) write[2]--;
+      else if (refundWindow === write[0] - windowSeconds) write[1]--;
+      else if (refundWindow === write[0] + windowSeconds) write[3]--;
+    }
+    if (!this.timeout) {
+      this.timeout = setTimeout(() => this._dump(), FLUSH_INTERVAL_MS);
+    }
+  }
+
   private async _read(
     now: number,
     buckets: RateLimitBucket[],
-  ): Promise<[number, number][]> {
+  ): Promise<ReadTuple[]> {
     const client = await this.redisClientFactory.getClient();
 
-    const fetched: ([number, number] | undefined)[] = buckets.map((x) =>
+    const fetched: (ReadTuple | undefined)[] = buckets.map((x) =>
       this.reads.get(x.key),
     );
     const fetchVals: string[] = [];
-    const lockedKeys: [number, Promise<[number, number]>][] = [];
-    const fetchKeys: [number, string][] = [];
+    const lockedKeys: [number, Promise<ReadTuple>][] = [];
+    const fetchKeys: [number, string, number][] = [];
     for (const [i, res] of fetched.entries()) {
-      if (res) continue;
       const { windowSeconds, key } = buckets[i];
+      const window = Math.floor(now / windowSeconds) * windowSeconds;
+      if (res && res[0] === window) continue;
       const lock = this.fetchLocks.get(key);
       if (lock) {
         lockedKeys.push([i, lock]);
         continue;
       }
-      const window = Math.floor(now / windowSeconds) * windowSeconds;
       const prev = `${BUCKET_NAMESPACE}:${window - windowSeconds}:${key}`;
       const curr = `${BUCKET_NAMESPACE}:${window}:${key}`;
       fetchVals.push(prev, curr);
-      fetchKeys.push([i, key]);
+      fetchKeys.push([i, key, window]);
     }
-    if (!fetchVals.length && !lockedKeys.length)
-      return fetched as [number, number][];
+    if (!fetchVals.length && !lockedKeys.length) return fetched as ReadTuple[];
 
-    const locks = fetchKeys.map(() =>
-      Promise.withResolvers<[number, number]>(),
-    );
+    const locks = fetchKeys.map(() => Promise.withResolvers<ReadTuple>());
     locks.forEach((l) => l.promise.catch(EmptyFn));
     fetchKeys.forEach(([_i, k], i) => this.fetchLocks.set(k, locks[i].promise));
     try {
       const values = fetchVals.length ? await client.mGet(fetchVals) : [];
-      for (const [i, [j, key]] of fetchKeys.entries()) {
-        const value: [number, number] = [
+      for (const [i, [j, key, window]] of fetchKeys.entries()) {
+        const value: ReadTuple = [
+          window,
           +(values[i * 2] || 0),
           +(values[i * 2 + 1] || 0),
         ];
@@ -138,7 +196,7 @@ export class RateLimitService {
       for (const [i, [j]] of lockedKeys.entries()) {
         fetched[j] = lockValues[i];
       }
-      return fetched as [number, number][];
+      return fetched as ReadTuple[];
     } catch (e) {
       locks.forEach((lock) => lock.reject(e));
       throw e;
@@ -162,16 +220,16 @@ export class RateLimitService {
     const writes = this.writes;
     this.writes = new Map();
     const multi = client.multi();
-    const now = Math.floor(Date.now() / 1000);
+    const tmp = new Map<string, ReadTuple>();
 
-    for (const [k, v] of writes) {
-      const read = this.reads.get(k) || [0, 0];
-      this.reads.set(k, [read[0], read[1] + v]);
+    for (const [k, w] of writes) {
       const sample = +k.substring(0, k.indexOf(":"));
-      const current = Math.floor(now / sample) * sample;
-      const key = `${BUCKET_NAMESPACE}:${current}:${k}`;
-      multi.incrBy(key, v);
-      multi.expireAt(key, current + sample * 2);
+      const r = this.reads.get(k) || [w[0], 0, 0];
+      tmp.set(k, r);
+      this.reads.set(k, AddWritesToRead(r, w, sample));
+      SetKey(multi, k, w[1], w[0] - sample, sample);
+      SetKey(multi, k, w[2], w[0], sample);
+      SetKey(multi, k, w[3], w[0] + sample, sample);
     }
     try {
       await multi.exec();
@@ -179,10 +237,37 @@ export class RateLimitService {
     } catch (e) {
       this.logger.error(e, "Error writing rate limit values");
       // merge writes back into map since we don't want to lose it
-      for (const [key, v] of writes) {
-        this.reads.get(key)![1] -= v; // since we previously set it
-        this.writes.set(key, (this.writes.get(key) || 0) + v);
+      for (const [k, v] of tmp.entries()) {
+        this.reads.set(k, v);
       }
     }
   }
 }
+
+const AddWritesToRead = (
+  r: ReadTuple,
+  w: WriteTuple,
+  sample: number,
+): ReadTuple => {
+  // my brain ain't working but there must be an easier way to do this
+  if (r[0] === w[0]) return [r[0], r[1] + w[1], r[2] + w[2]];
+  if (r[0] === w[0] - sample) return [r[0], r[1], r[2] + w[1]];
+  if (r[0] === w[0] + sample) return [r[0], r[1] + w[2], r[2] + w[3]];
+  if (r[0] === w[0] + 2 * sample) return [r[0], r[1] + w[3], r[2]];
+  return [...r];
+};
+
+const SetKey = (
+  multi: ReturnType<
+    Awaited<ReturnType<RedisClientFactory["getClient"]>>["multi"]
+  >,
+  k: string,
+  v: number,
+  current: number,
+  sample: number,
+) => {
+  if (v === 0) return;
+  const ns = `${BUCKET_NAMESPACE}:${current}:${k}`;
+  multi.incrBy(ns, v);
+  multi.expireAt(ns, current + sample * 2);
+};


### PR DESCRIPTION
- Record the read and written values rather than just using the current time. Otherwise it might skew badly.
- Allow for refunds, currently unused however we should have a use-case for this.
- Change the location of the read function, sometimes reads aren't cleared properly if it's before an await point

this is totally unnecessary but was bored so i kinda just wanted to look into it