### PR TITLE
Add bypass permissions to bypass checks

### DIFF
--- a/apps/server/src/hooks/rate_limit.ts
+++ b/apps/server/src/hooks/rate_limit.ts
@@ -17,7 +17,10 @@ export const RateLimitHook = async (
   reply: FastifyReply,
 ) => {
   if (DISABLE_RATE_LIMIT) return;
-  const { rateLimitService } = request.server.container.cradle;
+  const { rateLimitService, policyService } = request.server.container.cradle;
+  if (await policyService.evaluate(request.user?.id, ["bypass.rate_limit"])) {
+    return;
+  }
   const config = request.routeOptions.schema?.rateLimit || DEFAULT_CONFIG;
   let buckets: RateLimitBucket[] = [];
   if (typeof config === "function") {

--- a/core/mod-captcha/src/index.ts
+++ b/core/mod-captcha/src/index.ts
@@ -4,12 +4,14 @@ import { ValidationError } from "@noctf/server-core/errors";
 import { CloudflareCaptchaProvider, HCaptchaProvider } from "./provider.ts";
 import type { FastifyInstance, HTTPMethods } from "fastify";
 import { CaptchaHTTPMethod } from "@noctf/api/types";
+import "@noctf/server-core/types/fastify";
 
 const VALID_METHODS = new Set(
   Object.values(CaptchaHTTPMethod),
 ) as Set<HTTPMethods>;
 
 export async function initServer(fastify: FastifyInstance) {
+  const { policyService } = fastify.container.cradle;
   const service = new CaptchaService(fastify.container.cradle);
   service.register(new HCaptchaProvider());
   service.register(new CloudflareCaptchaProvider());
@@ -23,10 +25,16 @@ export async function initServer(fastify: FastifyInstance) {
         },
       },
     },
-    async () => {
+    async (request) => {
       const { provider, public_key, private_key, routes } =
         await service.getConfig();
-      if (!provider || !public_key || !private_key || !routes) {
+      if (
+        !provider ||
+        !public_key ||
+        !private_key ||
+        !routes ||
+        (await policyService.evaluate(request.user?.id, ["bypass.captcha"]))
+      ) {
         return { data: null };
       }
       return {
@@ -57,7 +65,8 @@ export async function initServer(fastify: FastifyInstance) {
       !public_key ||
       !private_key ||
       !routes ||
-      !routes.some((x) => method === x.method && path === x.path)
+      !routes.some((x) => method === x.method && path === x.path) ||
+      (await policyService.evaluate(request.user?.id, ["bypass.captcha"]))
     ) {
       return;
     }

--- a/migrations/1728563191178_user.ts
+++ b/migrations/1728563191178_user.ts
@@ -115,7 +115,7 @@ export async function up(db: Kysely<any>): Promise<void> {
       {
         name: "user",
         description: "Standard user permissions",
-        permissions: ["*", "!admin.*"],
+        permissions: ["*", "!admin.*", "!bypass.*"],
         match_roles: ["active"],
         is_enabled: true,
       },


### PR DESCRIPTION
Add bypass permissions to bypass checks

bypass.rate_limit for bypassing the rate limiter for all routes. bypass.captcha for bypassing captcha under all routes
don't want to allow admin otherwise it will show the admin panel