### PR TITLE
Optimise and add versioning on policy

### DIFF
--- a/apps/server/src/routes/admin_policy.ts
+++ b/apps/server/src/routes/admin_policy.ts
@@ -118,7 +118,7 @@ export async function routes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      await policyService.delete(request.params.id, {
+      await policyService.delete(request.params.id, undefined, {
         actor: {
           type: ActorType.USER,
           id: request.user.id,

--- a/apps/server/src/routes/admin_user.ts
+++ b/apps/server/src/routes/admin_user.ts
@@ -1,5 +1,4 @@
 import { SetupConfig } from "@noctf/api/config";
-import { UserIdentity } from "@noctf/api/datatypes";
 import { IdParams } from "@noctf/api/params";
 import { SessionQuery } from "@noctf/api/query";
 import {
@@ -21,7 +20,6 @@ import {
 import { ActorType, EntityType } from "@noctf/server-core/types/enums";
 import { Paginate } from "@noctf/server-core/util/paginator";
 import { Policy } from "@noctf/server-core/util/policy";
-import { RunInParallelWithLimit } from "@noctf/server-core/util/semaphore";
 import { FastifyInstance } from "fastify";
 
 export const PAGE_SIZE = 60;

--- a/apps/web/src/routes/admin/policies/+page.svelte
+++ b/apps/web/src/routes/admin/policies/+page.svelte
@@ -124,7 +124,7 @@
     editForm.is_enabled = true;
   }
 
-  async function updatePolicy() {
+  async function updatePolicy(version: number) {
     if (!editingPolicy || !editForm.name.trim()) {
       toasts.error("Please enter a policy name");
       return;
@@ -142,6 +142,7 @@
           permissions: parseArrayField(editForm.permissions),
           public: editForm.public,
           is_enabled: editForm.is_enabled,
+          version,
         },
       });
 
@@ -461,7 +462,7 @@
                   </button>
                   <button
                     class="btn btn-primary pop hover:pop"
-                    onclick={updatePolicy}
+                    onclick={() => updatePolicy(policy.version)}
                     disabled={isUpdating}
                   >
                     {#if isUpdating}

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -97,6 +97,7 @@ export const PolicyDocument = Type.Object({
   public: Type.Boolean(),
   is_enabled: Type.Boolean(),
   created_at: TypeDate,
+  updated_at: TypeDate,
   version: Type.Integer(),
 });
 export type PolicyDocument = Static<typeof PolicyDocument>;

--- a/core/api/src/enums.ts
+++ b/core/api/src/enums.ts
@@ -7,3 +7,10 @@ export const SubmissionStatus = Type.Enum({
   Invalid: "invalid",
 });
 export type SubmissionStatus = Static<typeof SubmissionStatus>;
+
+export const PolicyUpdateType = Type.Enum({
+  Create: "create",
+  Update: "update",
+  Delete: "delete",
+});
+export type PolicyUpdateType = Static<typeof PolicyUpdateType>;

--- a/core/api/src/events.ts
+++ b/core/api/src/events.ts
@@ -1,5 +1,5 @@
 import { Static, Type } from "@sinclair/typebox";
-import { SubmissionStatus } from "./enums.ts";
+import { PolicyUpdateType, SubmissionStatus } from "./enums.ts";
 import { EmailAddressOrUserId, TypeDate } from "./datatypes.ts";
 
 export const SubmissionUpdateEvent = Type.Object(
@@ -48,6 +48,7 @@ export const PolicyUpdateEvent = Type.Object(
     id: Type.Integer(),
     version: Type.Integer(),
     updated_at: TypeDate,
+    type: PolicyUpdateType,
   },
   { $id: "events.policy.update" },
 );

--- a/core/api/src/requests.ts
+++ b/core/api/src/requests.ts
@@ -407,10 +407,20 @@ export type AdminUpdateDivisionRequest = Static<
   typeof AdminUpdateDivisionRequest
 >;
 
-export const AdminCreatePolicyRequest = Type.Omit(PolicyDocument, ["id"], {
-  additionalProperties: false,
-});
+export const AdminCreatePolicyRequest = Type.Omit(
+  PolicyDocument,
+  ["id", "created_at", "updated_at", "version"],
+  {
+    additionalProperties: false,
+  },
+);
 export type AdminCreatePolicyRequest = Static<typeof AdminCreatePolicyRequest>;
 
-export const AdminUpdatePolicyRequest = AdminCreatePolicyRequest;
+export const AdminUpdatePolicyRequest = Type.Omit(
+  PolicyDocument,
+  ["id", "created_at", "updated_at"],
+  {
+    additionalProperties: false,
+  },
+);
 export type AdminUpdatePolicyRequest = Static<typeof AdminUpdatePolicyRequest>;

--- a/core/server-core/src/services/policy.test.ts
+++ b/core/server-core/src/services/policy.test.ts
@@ -2,14 +2,13 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 import { PolicyDAO } from "../dao/policy.ts";
 import { UserDAO } from "../dao/user.ts";
-import { Evaluate } from "../util/policy.ts";
+import { Evaluate, PreprocessPermissions } from "../util/policy.ts";
 import { UserFlag } from "../types/enums.ts";
 import { PolicyService } from "./policy.ts";
 import { ServiceCradle } from "../index.ts";
 import { PolicyDocument } from "@noctf/api/datatypes";
 import { AuthConfig } from "@noctf/api/config";
-import { TeamDAO } from "../dao/team.ts";
-import { ConfigService, ConfigValue } from "./config.ts";
+import { ConfigValue } from "./config.ts";
 
 vi.mock(import("../dao/policy.ts"));
 vi.mock(import("../dao/user.ts"));
@@ -21,6 +20,7 @@ describe(PolicyService, () => {
   const logger = mockDeep<ServiceCradle["logger"]>();
   const configService = mockDeep<ServiceCradle["configService"]>();
   const auditLogService = mockDeep<ServiceCradle["auditLogService"]>();
+  const eventBusService = mockDeep<ServiceCradle["eventBusService"]>();
 
   const mockPolicyDAO = mockDeep<PolicyDAO>();
   const mockUserDAO = mockDeep<UserDAO>();
@@ -36,12 +36,14 @@ describe(PolicyService, () => {
 
     vi.mocked(PolicyDAO).mockImplementation(() => mockPolicyDAO);
     vi.mocked(UserDAO).mockImplementation(() => mockUserDAO);
+    vi.mocked(PreprocessPermissions).mockImplementation((x) => x);
 
     policyService = new PolicyService({
       databaseClient,
       logger,
       configService,
       auditLogService,
+      eventBusService,
     });
   });
 
@@ -64,6 +66,9 @@ describe(PolicyService, () => {
           permissions: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 2,
@@ -74,6 +79,9 @@ describe(PolicyService, () => {
           permissions: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 3,
@@ -84,6 +92,9 @@ describe(PolicyService, () => {
           permissions: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 4,
@@ -94,6 +105,9 @@ describe(PolicyService, () => {
           permissions: [],
           public: true,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
       ];
 
@@ -225,6 +239,9 @@ describe(PolicyService, () => {
           permissions: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 2,
@@ -235,6 +252,9 @@ describe(PolicyService, () => {
           permissions: [],
           public: true,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 3,
@@ -245,6 +265,9 @@ describe(PolicyService, () => {
           permissions: [],
           public: true,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
       ];
 
@@ -277,6 +300,9 @@ describe(PolicyService, () => {
           omit_roles: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 2,
@@ -287,6 +313,9 @@ describe(PolicyService, () => {
           omit_roles: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
       ];
 
@@ -311,6 +340,9 @@ describe(PolicyService, () => {
           omit_roles: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 2,
@@ -321,6 +353,9 @@ describe(PolicyService, () => {
           omit_roles: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
       ];
 
@@ -337,13 +372,16 @@ describe(PolicyService, () => {
       const mockPolicies: PolicyDocument[] = [
         {
           id: 1,
-          name: "PublicPolicy",
+          name: "NotPublicPolicy",
           description: "",
           permissions: ["dummy.1"],
           match_roles: [],
           omit_roles: [],
           public: false,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
         {
           id: 2,
@@ -354,6 +392,9 @@ describe(PolicyService, () => {
           omit_roles: [],
           public: true,
           is_enabled: true,
+          created_at: new Date(0),
+          updated_at: new Date(0),
+          version: 0,
         },
       ];
 

--- a/core/server-core/src/services/policy.ts
+++ b/core/server-core/src/services/policy.ts
@@ -1,21 +1,31 @@
 import { PolicyDAO } from "../dao/policy.ts";
 import type { ServiceCradle } from "../index.ts";
 import type { Policy } from "../util/policy.ts";
-import { Evaluate, EvaluatePrefixes } from "../util/policy.ts";
+import {
+  Evaluate,
+  EvaluatePrefixes,
+  PreprocessPermissions,
+} from "../util/policy.ts";
 import { LocalCache } from "../util/local_cache.ts";
 import { UserDAO } from "../dao/user.ts";
 import { AuthConfig } from "@noctf/api/config";
 import { EntityType, UserFlag, UserRole } from "../types/enums.ts";
 import SingleValueCache from "../util/single_value_cache.ts";
 import { AuditParams } from "../types/audit_log.ts";
+import { PolicyUpdateEvent } from "@noctf/api/events";
 
 type Props = Pick<
   ServiceCradle,
-  "databaseClient" | "logger" | "configService" | "auditLogService" | "policyService"
+  | "databaseClient"
+  | "logger"
+  | "configService"
+  | "auditLogService"
+  | "eventBusService"
 >;
 
 export const CACHE_NAMESPACE = "core:svc:policy";
 
+const USER_ROLES_EXPIRATION = 15000;
 const POLICY_EXPIRATION = 60000;
 
 export class PolicyService {
@@ -29,10 +39,14 @@ export class PolicyService {
 
   private readonly userRolesCache = new LocalCache<number, Set<string>>({
     max: 16384,
-    ttl: POLICY_EXPIRATION,
+    ttl: USER_ROLES_EXPIRATION,
   });
   private readonly policyGetter = new SingleValueCache(
-    () => this.policyDAO.list({ is_enabled: true }),
+    async () =>
+      (await this.policyDAO.list({ is_enabled: true })).map((x) => ({
+        ...x,
+        permissions: PreprocessPermissions(x.permissions),
+      })),
     POLICY_EXPIRATION,
   );
 
@@ -49,6 +63,25 @@ export class PolicyService {
     this.eventBusService = eventBusService;
     this.policyDAO = new PolicyDAO(databaseClient.get());
     this.userDAO = new UserDAO(databaseClient.get());
+    void this.subscribeUpdates();
+  }
+
+  /**
+   * Listen for config update messages
+   */
+  private async subscribeUpdates() {
+    await this.eventBusService.subscribe<PolicyUpdateEvent>(
+      new AbortController().signal,
+      undefined,
+      [PolicyUpdateEvent.$id!],
+      {
+        concurrency: 1,
+        handler: async () => {
+          // TODO: do a little more sophisticated parsing
+          this.policyGetter.clear();
+        },
+      },
+    );
   }
 
   async list() {
@@ -61,13 +94,21 @@ export class PolicyService {
   ) {
     const policy = await this.policyDAO.create(v);
     this.policyGetter.clear();
-    await this.auditLogService.log({
-      operation: "policy.create",
-      actor,
-      data: message,
-      entities: [`${EntityType.POLICY}:${policy.id}`],
-    });
-    await this.eventBusService.
+    await Promise.all([
+      this.auditLogService.log({
+        operation: "policy.create",
+        actor,
+        data: message,
+        entities: [`${EntityType.POLICY}:${policy.id}`],
+      }),
+      this.eventBusService.publish(PolicyUpdateEvent, {
+        type: "create",
+        id: policy.id,
+        name: policy.name,
+        updated_at: policy.updated_at,
+        version: policy.version,
+      }),
+    ]);
     return policy;
   }
 
@@ -76,19 +117,47 @@ export class PolicyService {
     v: Parameters<PolicyDAO["update"]>[1],
     { actor, message }: AuditParams = {},
   ) {
-    await this.policyDAO.update(id, v);
+    const result = await this.policyDAO.update(id, v);
     this.policyGetter.clear();
-    await this.auditLogService.log({
-      operation: "policy.update",
-      actor,
-      data: message,
-      entities: [`${EntityType.POLICY}:${id}`],
-    });
+    await Promise.all([
+      this.auditLogService.log({
+        operation: "policy.update",
+        actor,
+        data: message,
+        entities: [`${EntityType.POLICY}:${id}`],
+      }),
+      this.eventBusService.publish(PolicyUpdateEvent, {
+        type: "update",
+        id: id,
+        name: result.name,
+        updated_at: result.updated_at,
+        version: result.version,
+      }),
+    ]);
   }
 
-  async delete(id: number, { actor, message }: AuditParams = {}) {
-    await this.policyDAO.delete(id);
+  async delete(
+    id: number,
+    version?: number,
+    { actor, message }: AuditParams = {},
+  ) {
+    const result = await this.policyDAO.delete(id, version);
     this.policyGetter.clear();
+    await Promise.all([
+      this.auditLogService.log({
+        operation: "policy.delete",
+        actor,
+        data: message,
+        entities: [`${EntityType.POLICY}:${id}`],
+      }),
+      this.eventBusService.publish(PolicyUpdateEvent, {
+        type: "delete",
+        id: id,
+        name: result.name,
+        updated_at: new Date(),
+        version: result.version + 1,
+      }),
+    ]);
     await this.auditLogService.log({
       operation: "policy.delete",
       actor,

--- a/core/server-core/src/util/policy.ts
+++ b/core/server-core/src/util/policy.ts
@@ -69,11 +69,10 @@ export const EvaluatePrefixes = (
   prefixes: Set<string>,
   permissions: string[],
 ): string[] => {
-  const preprocessed = PreprocessPermissions(permissions);
   const matchingPrefixes: string[] = [];
 
   for (const prefix of prefixes) {
-    if (EvaluatePrefixScalar(prefix, preprocessed)) {
+    if (EvaluatePrefixScalar(prefix, permissions)) {
       matchingPrefixes.push(prefix);
       prefixes.delete(prefix);
     }
@@ -92,13 +91,12 @@ const RecursiveEvaluation = (
     return false;
   }
   const [op, ...expressions] = policy;
-  const preprocessed = PreprocessPermissions(permissions);
 
   const evaluate = (expr: string | Policy): boolean => {
     if (Array.isArray(expr)) {
       return RecursiveEvaluation(expr, permissions, scalar, _ttl - 1);
     } else {
-      return scalar(expr, preprocessed);
+      return scalar(expr, permissions);
     }
   };
 


### PR DESCRIPTION
Optimise policy by preprocessing when fetching policy. Also adding an event based system to purge cache. it's currently dumb but could be smarter.

Also add versioning to both UI

Will run this on all our tables
```
ALTER TABLE policy
  ADD COLUMN version INTEGER NOT NULL DEFAULT 1,
  ADD COLUMN created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
  ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
```