### PR TITLE
Use cursor based paginatrion for audit log

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -86,7 +86,8 @@ server.register(async () => {
       ({ logger }) => new RedisClientFactory(REDIS_URL, logger),
     ).singleton(),
     databaseClient: asFunction(
-      ({ logger }) => new DatabaseClient(logger, POSTGRES_URL),
+      ({ logger, keyService }) =>
+        new DatabaseClient(logger, keyService, POSTGRES_URL),
     ).singleton(),
     natsClientFactory: asFunction(
       ({ logger }) => new NATSClientFactory(logger, NATS_URL),

--- a/apps/server/src/routes/admin_submission.ts
+++ b/apps/server/src/routes/admin_submission.ts
@@ -10,7 +10,7 @@ import type { FastifyInstance } from "fastify";
 import "@noctf/server-core/types/fastify";
 import type { Policy } from "@noctf/server-core/util/policy";
 import { ActorType } from "@noctf/server-core/types/enums";
-import { Paginate } from "@noctf/server-core/util/paginator";
+import { OffsetPaginate } from "@noctf/server-core/util/paginator";
 
 export const PAGE_SIZE = 60;
 
@@ -44,7 +44,7 @@ export async function routes(fastify: FastifyInstance) {
     async (request) => {
       const { page, page_size, ...query } = request.body;
       const [result, total] = await Promise.all([
-        Paginate(query, { page, page_size }, (q, l) =>
+        OffsetPaginate(query, { page, page_size }, (q, l) =>
           submissionService.listSummary(q, l),
         ),
         submissionService.getCount(query),

--- a/apps/server/src/routes/admin_team.ts
+++ b/apps/server/src/routes/admin_team.ts
@@ -10,7 +10,7 @@ import {
   UpdateTeamResponse,
 } from "@noctf/api/responses";
 import { ActorType } from "@noctf/server-core/types/enums";
-import { Paginate } from "@noctf/server-core/util/paginator";
+import { OffsetPaginate } from "@noctf/server-core/util/paginator";
 import { FastifyInstance } from "fastify";
 
 export const PAGE_SIZE = 60;
@@ -37,7 +37,7 @@ export async function routes(fastify: FastifyInstance) {
     async (request) => {
       const { page, page_size, ...query } = request.body;
       const [result, total] = await Promise.all([
-        Paginate(query, { page, page_size }, (q, l) =>
+        OffsetPaginate(query, { page, page_size }, (q, l) =>
           teamService.listSummary(q, l),
         ),
         query.ids && query.ids.length ? 0 : teamService.getCount(query),

--- a/apps/server/src/routes/admin_user.ts
+++ b/apps/server/src/routes/admin_user.ts
@@ -18,7 +18,7 @@ import {
   NotFoundError,
 } from "@noctf/server-core/errors";
 import { ActorType, EntityType } from "@noctf/server-core/types/enums";
-import { Paginate } from "@noctf/server-core/util/paginator";
+import { OffsetPaginate } from "@noctf/server-core/util/paginator";
 import { Policy } from "@noctf/server-core/util/policy";
 import { FastifyInstance } from "fastify";
 
@@ -60,7 +60,7 @@ export async function routes(fastify: FastifyInstance) {
       const { page, page_size, ...query } = request.body;
       const [{ entries, page_size: actual_page_size }, total] =
         await Promise.all([
-          Paginate(query, { page, page_size }, (q, l) =>
+          OffsetPaginate(query, { page, page_size }, (q, l) =>
             userService.listSummary(q, l),
           ),
           query.ids && query.ids.length ? 0 : userService.getCount(query),

--- a/apps/server/src/routes/team.ts
+++ b/apps/server/src/routes/team.ts
@@ -24,7 +24,7 @@ import {
 import { ActorType, TeamFlag } from "@noctf/server-core/types/enums";
 import { Policy } from "@noctf/server-core/util/policy";
 import SingleValueCache from "@noctf/server-core/util/single_value_cache";
-import { Paginate } from "@noctf/server-core/util/paginator";
+import { OffsetPaginate } from "@noctf/server-core/util/paginator";
 import { GetRouteUserIPKey } from "@noctf/server-core/util/limit_keys";
 
 export async function routes(fastify: FastifyInstance) {
@@ -331,7 +331,7 @@ export async function routes(fastify: FastifyInstance) {
         flags: admin ? [] : ["!hidden"],
       };
       const [result, total] = await Promise.all([
-        Paginate(q, { page, page_size }, (q, l) =>
+        OffsetPaginate(q, { page, page_size }, (q, l) =>
           teamService.listSummary(q, l),
         ),
         q.ids && q.ids.length ? 0 : teamService.getCount(q),

--- a/apps/server/src/routes/user.ts
+++ b/apps/server/src/routes/user.ts
@@ -11,7 +11,7 @@ import {
 } from "@noctf/api/responses";
 import { ConflictError, NotFoundError } from "@noctf/server-core/errors";
 import { Policy } from "@noctf/server-core/util/policy";
-import { Paginate } from "@noctf/server-core/util/paginator";
+import { OffsetPaginate } from "@noctf/server-core/util/paginator";
 
 export async function routes(fastify: FastifyInstance) {
   const { userService, teamService, policyService, identityService } = fastify
@@ -153,7 +153,7 @@ export async function routes(fastify: FastifyInstance) {
         flags: admin ? [] : ["!hidden"],
       };
       const [result, total] = await Promise.all([
-        Paginate(q, { page, page_size }, (q, l) =>
+        OffsetPaginate(q, { page, page_size }, (q, l) =>
           userService.listSummary(q, l),
         ),
         q.ids && q.ids.length ? 0 : userService.getCount(q),

--- a/apps/web/src/lib/components/Header.svelte
+++ b/apps/web/src/lib/components/Header.svelte
@@ -90,64 +90,65 @@
       <a href="/auth" class="btn btn-primary px-6 sm:px-8 pop hover:pop"
         >Login</a
       >
-    {/if}
-    <div class="dropdown dropdown-end">
-      <div
-        tabindex="0"
-        role="button"
-        class="btn hover:pop pop flex flex-row gap-0 px-2 bg-base-100 items-center"
-        aria-label="User menu"
-      >
-        <Icon
-          icon="material-symbols:account-circle"
-          class="text-3xl lg:text-4xl text-neutral-600"
-        />
+    {:else if authState.isAuthenticated}
+      <div class="dropdown dropdown-end">
         <div
-          class="hidden sm:flex flex-col items-start pl-2 lg:min-w-32 max-w-32 gap-0"
+          tabindex="0"
+          role="button"
+          class="btn hover:pop pop flex flex-row gap-0 px-2 bg-base-100 items-center"
+          aria-label="User menu"
         >
+          <Icon
+            icon="material-symbols:account-circle"
+            class="text-3xl lg:text-4xl text-neutral-600"
+          />
           <div
-            class="text-left text-sm lg:text-base font-medium w-full truncate"
+            class="hidden sm:flex flex-col items-start pl-2 lg:min-w-32 max-w-32 gap-0"
           >
-            {authState.user?.name}
-          </div>
-          {#if authState.user?.team_name}
             <div
-              class="text-left text-neutral-400 text-xs lg:text-sm hidden sm:block w-full truncate -mt-1"
+              class="text-left text-sm lg:text-base font-medium w-full truncate"
+            >
+              {authState.user?.name}
+            </div>
+            {#if authState.user?.team_name}
+              <div
+                class="text-left text-neutral-400 text-xs lg:text-sm hidden sm:block w-full truncate -mt-1"
+              >
+                {authState.user?.team_name}
+              </div>
+            {/if}
+          </div>
+          <Icon icon="mdi:chevron-down" class="hidden sm:block ml-1" />
+        </div>
+        <ul
+          class="menu menu-sm dropdown-content mt-3 z-[10] p-1 px-2 pop bg-base-100 rounded-box w-52 gap-0"
+          tabindex="-1"
+        >
+          <li class="flex flex-col sm:hidden pointer-events-none w-full gap-0">
+            <div class="w-full font-semibold truncate">
+              {authState.user?.name}
+            </div>
+            <div
+              class="text-neutral-400 w-full font-semibold text-xs -mt-1 truncate"
             >
               {authState.user?.team_name}
             </div>
-          {/if}
-        </div>
-        <Icon icon="mdi:chevron-down" class="hidden sm:block ml-1" />
+          </li>
+          <div class="sm:hidden divider py-0 mt-1 mb-0"></div>
+          <li class="py-1">
+            <a href="/team" class={isActive("/team")}>Team</a>
+          </li>
+          <li class="py-1">
+            <a href="/settings" class={isActive("/settings")}>Settings</a>
+          </li>
+          <li>
+            <button
+              onclick={authState.logout}
+              class="text-error w-full text-left p-2">Logout</button
+            >
+          </li>
+        </ul>
       </div>
-      <ul
-        class="menu menu-sm dropdown-content mt-3 z-[10] p-1 px-2 pop bg-base-100 rounded-box w-52 gap-0"
-        tabindex="-1"
-      >
-        <li class="flex flex-col sm:hidden pointer-events-none w-full gap-0">
-          <div class="w-full font-semibold truncate">
-            {authState.user?.name}
-          </div>
-          <div
-            class="text-neutral-400 w-full font-semibold text-xs -mt-1 truncate"
-          >
-            {authState.user?.team_name}
-          </div>
-        </li>
-        <div class="sm:hidden divider py-0 mt-1 mb-0"></div>
-        <li class="py-1">
-          <a href="/team" class={isActive("/team")}>Team</a>
-        </li>
-        <li class="py-1">
-          <a href="/settings" class={isActive("/settings")}>Settings</a>
-        </li>
-        <li>
-          <button
-            onclick={authState.logout}
-            class="text-error w-full text-left p-2">Logout</button
-          >
-        </li>
-      </ul>
-    </div>
+    {/if}
   </div>
 </div>

--- a/core/api/src/requests.ts
+++ b/core/api/src/requests.ts
@@ -145,7 +145,6 @@ export const QueryAuditLogRequest = Type.Object(
     actor: Type.Optional(Type.Array(Type.String())),
     entities: Type.Optional(Type.Array(Type.String())),
     operation: Type.Optional(Type.Array(Type.String())),
-    page: Type.Optional(Type.Number()),
     page_size: Type.Optional(Type.Number()),
   },
   { additionalProperties: false },

--- a/core/api/src/responses.ts
+++ b/core/api/src/responses.ts
@@ -88,7 +88,6 @@ export const QueryAuditLogResponse = Type.Object({
   data: Type.Object({
     entries: Type.Array(AuditLogEntry),
     page_size: Type.Number(),
-    total: Type.Number(),
   }),
 });
 export type QueryAuditLogResponse = Static<typeof QueryAuditLogResponse>;

--- a/core/server-core/src/clients/database.ts
+++ b/core/server-core/src/clients/database.ts
@@ -3,13 +3,30 @@ import { Kysely, PostgresDialect } from "kysely";
 import pg from "pg";
 import type { DB } from "@noctf/schema";
 import type { Logger } from "../types/primitives.ts";
+import { KeyService } from "../services/key.ts";
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHmac,
+  randomBytes,
+} from "node:crypto";
+import { decode, encode } from "cbor-x";
+import { PaginationCursor } from "../types/pagination.ts";
+import { BadRequestError } from "../errors.ts";
+
+// Encoding version, forms part of the key as the server doesn't need to decode old versions
+const DB_CURSOR_ENCODING_VERSION = 1;
 
 export type DBType = Kysely<DB>;
 
 export class DatabaseClient {
   private readonly client: DBType;
 
-  constructor(logger: Logger | null, connectionString: string) {
+  constructor(
+    logger: Logger | null,
+    private readonly keyService: KeyService,
+    connectionString: string,
+  ) {
     if (logger) {
       const url = new URL(connectionString);
       logger.info(`Connecting to postgres at ${url.host}:${url.port || 5432}`);
@@ -36,5 +53,54 @@ export class DatabaseClient {
 
   get() {
     return this.client.withSchema("public");
+  }
+
+  encodePaginationToken(operation: string, data: PaginationCursor) {
+    const key = this.keyService.deriveKey(
+      `database:pagination:v${DB_CURSOR_ENCODING_VERSION}`,
+    );
+    const opKey = createHmac("sha256", key).update(operation).digest();
+    const payload = encode(data);
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", opKey, iv, {
+      authTagLength: 12,
+    });
+    const encrypted = cipher.update(payload);
+    cipher.final();
+    const out = Buffer.concat([encrypted, iv, cipher.getAuthTag()]);
+    return out.toString("base64url");
+  }
+
+  decodePaginationToken(operation: string, payload: string) {
+    const buf = Buffer.from(payload, "base64url");
+    if (buf.length < 24) {
+      throw new BadRequestError(
+        "InvalidPaginationToken",
+        "Invalid pagination token",
+        { cause: "Invalid pagination token length" },
+      );
+    }
+    const key = this.keyService.deriveKey(
+      `database:pagination:v${DB_CURSOR_ENCODING_VERSION}`,
+    );
+    const opKey = createHmac("sha256", key).update(operation).digest();
+    const cipher = createDecipheriv(
+      "aes-256-gcm",
+      opKey,
+      buf.subarray(buf.length - 24, 12),
+    );
+    cipher.setAuthTag(buf.subarray(buf.length - 12));
+    const decrypted = cipher.update(buf.subarray(0, buf.length - 24));
+    try {
+      cipher.final();
+    } catch (e) {
+      throw new BadRequestError(
+        "InvalidPaginationToken",
+        "Invalid pagination token",
+        { cause: e },
+      );
+    }
+    const decoded: PaginationCursor = decode(decrypted);
+    return decoded;
   }
 }

--- a/core/server-core/src/dao/audit_log.ts
+++ b/core/server-core/src/dao/audit_log.ts
@@ -2,6 +2,7 @@ import type { QueryAuditLogRequest } from "@noctf/api/requests";
 import type { DBType } from "../clients/database.ts";
 import { sql } from "kysely";
 import type { AuditLogEntry, LimitOffset } from "@noctf/api/datatypes";
+import { LimitCursorDecoded } from "../types/pagination.ts";
 
 export class AuditLogDAO {
   constructor(private readonly db: DBType) {}
@@ -24,7 +25,7 @@ export class AuditLogDAO {
 
   async query(
     params?: Parameters<AuditLogDAO["listQuery"]>[0],
-    limit?: LimitOffset,
+    limit?: number,
   ): Promise<AuditLogEntry[]> {
     let query = this.listQuery(params).select([
       "actor",
@@ -34,16 +35,10 @@ export class AuditLogDAO {
       "created_at",
     ]);
 
-    if (limit?.limit) {
-      query = query.limit(limit.limit);
+    if (limit) {
+      query = query.limit(limit);
     }
-    if (limit?.offset) {
-      query = query.offset(limit.offset);
-    }
-    return query
-      .orderBy("created_at desc")
-      .offset(limit?.offset || 0)
-      .execute();
+    return query.orderBy("created_at desc").execute();
   }
 
   async getCount(

--- a/core/server-core/src/services/audit_log.ts
+++ b/core/server-core/src/services/audit_log.ts
@@ -4,6 +4,7 @@ import type { ServiceCradle } from "../index.ts";
 import type { AuditLogActor } from "../types/audit_log.ts";
 import { ActorType } from "../types/enums.ts";
 import { AuditLogDAO } from "../dao/audit_log.ts";
+import { LimitCursorEncoded, PaginationCursor } from "../types/pagination.ts";
 
 type Props = Pick<ServiceCradle, "databaseClient">;
 
@@ -13,8 +14,10 @@ export const SYSTEM_ACTOR: AuditLogActor = {
 
 export class AuditLogService {
   private readonly dao;
+  private readonly databaseClient;
 
   constructor({ databaseClient }: Props) {
+    this.databaseClient = databaseClient;
     this.dao = new AuditLogDAO(databaseClient.get());
   }
 
@@ -35,7 +38,7 @@ export class AuditLogService {
 
   async query(
     q: Omit<QueryAuditLogRequest, "page" | "page_size">,
-    limit?: { limit?: number; offset?: number },
+    limit?: number,
   ): Promise<AuditLogEntry[]> {
     return this.dao.query(q, limit);
   }

--- a/core/server-core/src/types/pagination.ts
+++ b/core/server-core/src/types/pagination.ts
@@ -1,0 +1,13 @@
+import { Primitive } from "@noctf/api/types";
+
+export type PaginationCursor = Record<string, Primitive | Date | BigInt>;
+
+export type LimitCursorEncoded = {
+  limit?: number;
+  next?: string;
+};
+
+export type LimitCursorDecoded = {
+  limit?: number;
+  next?: PaginationCursor;
+};

--- a/core/server-core/src/util/paginator.test.ts
+++ b/core/server-core/src/util/paginator.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { Paginate, type PaginateOptions } from "./paginator.ts";
+import { OffsetPaginate, type PaginateOptions } from "./paginator.ts";
 
 describe("Paginate", () => {
   // Mock data for testing
@@ -24,7 +24,7 @@ describe("Paginate", () => {
 
   describe("Basic functionality", () => {
     it("should return first page with default page size", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1 },
         mockQueryFn,
@@ -41,7 +41,7 @@ describe("Paginate", () => {
     });
 
     it("should return second page with correct offset", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 2, page_size: 20 },
         mockQueryFn,
@@ -58,7 +58,7 @@ describe("Paginate", () => {
     });
 
     it("should work with custom page size", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: 25 },
         mockQueryFn,
@@ -77,7 +77,7 @@ describe("Paginate", () => {
 
   describe("Default values", () => {
     it("should default to page 1 when page is not provided", async () => {
-      const result = await Paginate({ filter: "test" }, {}, mockQueryFn);
+      const result = await OffsetPaginate({ filter: "test" }, {}, mockQueryFn);
 
       expect(mockQueryFn).toHaveBeenCalledWith(
         { filter: "test" },
@@ -86,7 +86,7 @@ describe("Paginate", () => {
     });
 
     it("should default to page 1 when page is null/undefined", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: undefined },
         mockQueryFn,
@@ -99,7 +99,7 @@ describe("Paginate", () => {
     });
 
     it("should use default page size when not provided", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1 },
         mockQueryFn,
@@ -111,7 +111,7 @@ describe("Paginate", () => {
 
   describe("Page size limits", () => {
     it("should enforce max page size limit", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: 200 }, // Exceeds default max of 100
         mockQueryFn,
@@ -125,7 +125,7 @@ describe("Paginate", () => {
     });
 
     it("should allow page size up to max limit", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: 100 },
         mockQueryFn,
@@ -141,7 +141,7 @@ describe("Paginate", () => {
         max_page_size: 200,
       };
 
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: 150 },
         mockQueryFn,
@@ -156,7 +156,7 @@ describe("Paginate", () => {
         default_page_size: 25,
       };
 
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1 }, // No page_size provided
         mockQueryFn,
@@ -172,7 +172,7 @@ describe("Paginate", () => {
         // default_page_size not provided, should use default of 50
       };
 
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: 80 }, // Exceeds custom max
         mockQueryFn,
@@ -187,7 +187,7 @@ describe("Paginate", () => {
         max_page_size: 0, // Unlimited
       };
 
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: 500 }, // Very large page size
         mockQueryFn,
@@ -206,7 +206,7 @@ describe("Paginate", () => {
     it("should handle empty results", async () => {
       const emptyQueryFn = vi.fn(async () => []);
 
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "empty" },
         { page: 1, page_size: 10 },
         emptyQueryFn,
@@ -219,7 +219,7 @@ describe("Paginate", () => {
     });
 
     it("should handle page beyond available data", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 100, page_size: 10 }, // Way beyond available data
         mockQueryFn,
@@ -233,7 +233,7 @@ describe("Paginate", () => {
     });
 
     it("should handle zero page size by using default", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: 0 },
         mockQueryFn,
@@ -243,7 +243,7 @@ describe("Paginate", () => {
     });
 
     it("should handle negative page size by using default", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: 1, page_size: -10 },
         mockQueryFn,
@@ -253,7 +253,7 @@ describe("Paginate", () => {
     });
 
     it("should handle negative page by defaulting to page 1", async () => {
-      const result = await Paginate(
+      const result = await OffsetPaginate(
         { filter: "test" },
         { page: -5, page_size: 10 },
         mockQueryFn,

--- a/core/server-core/src/util/paginator.ts
+++ b/core/server-core/src/util/paginator.ts
@@ -8,7 +8,7 @@ const DEFAULT_PAGINATE_OPTIONS: PaginateOptions = {
   default_page_size: 50,
 };
 
-export const Paginate = async <Q, T>(
+export const OffsetPaginate = async <Q, T>(
   query: Q,
   { page_size, page }: { page_size?: number; page?: number },
   queryFn: (
@@ -40,5 +40,38 @@ export const Paginate = async <Q, T>(
   return {
     entries,
     page_size,
+  };
+};
+
+export const CursorPaginate = async <Q, T>(
+  query: Q,
+  { page_size, next }: { page_size?: number; next?: string },
+  queryFn: (
+    q: Q,
+    limit: { limit: number; next?: string },
+  ) => [T[], string] | Promise<[T[], string]>,
+  opts: Partial<PaginateOptions> = {},
+): Promise<{
+  entries: T[];
+  page_size: number;
+  next: string;
+}> => {
+  const o = { ...DEFAULT_PAGINATE_OPTIONS, ...opts };
+  page_size = page_size =
+    o.max_page_size === 0
+      ? page_size || o.default_page_size
+      : Math.min(o.max_page_size, page_size || o.default_page_size);
+  if (page_size < 0) {
+    page_size = o.default_page_size;
+  }
+  const [entries, cursor] = await queryFn(query, {
+    limit: page_size,
+    next,
+  });
+
+  return {
+    entries,
+    page_size,
+    next: cursor,
   };
 };


### PR DESCRIPTION
Aparently offset based pagination is very bad for large tables, which the audit table would be. Just going to fix up the audit table for now (and maybe submissions later to use cursor based). Also we don't really need or care about the number of results for audit.

Added a encrypted cursor however this is currently unused.

https://use-the-index-luke.com/no-offset