### PR TITLE
add expiry to local chal details

### DIFF
--- a/apps/web/src/routes/challenges/+page.svelte
+++ b/apps/web/src/routes/challenges/+page.svelte
@@ -13,7 +13,7 @@
   import { toasts } from "$lib/stores/toast";
   import Icon from "@iconify/svelte";
 
-  const CHALLENGE_DETAIL_CACHE_TIME = 1000 * 60 * 10; // 10 minutes
+  const CHALLENGE_DETAIL_CACHE_TIME = 1000 * 60 * 5; // 5 minutes
 
   let apiChallenges = $state(wrapLoadable(api.GET("/challenges")));
   let challDetailsMap: {


### PR DESCRIPTION
This will fix users flicking between chals and getting the stale attachment URL. 

This won't fix a user staying on a chal page for 15 minutes and not changing. I think we could do a setTimeout() or something but just wanted to get this in