### PR TITLE
make data structures more efficient when transferring over the wire

### DIFF
--- a/apps/server/src/routes/scoreboard.ts
+++ b/apps/server/src/routes/scoreboard.ts
@@ -79,14 +79,14 @@ export async function routes(fastify: FastifyInstance) {
             scoreboard.entries.map(({ team_id }) => team_id),
           )
         : new Map();
+
       const entries = scoreboard.entries.map((e) => ({
         ...e,
         solves: admin ? e.solves : e.solves.filter((x) => !x.hidden),
-        graph:
-          WindowDeltaedTimeSeriesPoints(
-            graphs.get(e.team_id),
-            request.query.graph_interval || 1,
-          ) || [],
+        graph: WindowDeltaedTimeSeriesPoints(
+          graphs.get(e.team_id),
+          request.query.graph_interval || 1,
+        ),
       }));
 
       return {
@@ -159,7 +159,7 @@ export async function routes(fastify: FastifyInstance) {
           ...entry,
           solves,
           graph: WindowDeltaedTimeSeriesPoints(
-            graph.get(request.params.id) || [],
+            graph.get(request.params.id) || [[], []],
             request.query.graph_interval || 1,
           ),
         },

--- a/apps/web/src/lib/components/scoreboard/Graph.svelte
+++ b/apps/web/src/lib/components/scoreboard/Graph.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   export interface TeamChartData {
     name: string | undefined;
-    data: Array<[number, number]>; // [timestamp, score]
+    data: [number[], number[]]; // [timestamp, score]
   }
 
   interface DataPoint {
@@ -52,9 +52,9 @@
       let y = 0;
       return {
         label: team.name,
-        data: team.data.map(([timestamp, score]) => {
+        data: team.data[0].map((timestamp, idx) => {
           x = x + timestamp * 1000;
-          y = y + score;
+          y = y + team.data[1][idx]!;
           return {
             x,
             y,
@@ -63,8 +63,8 @@
         borderColor: lineColours[index % lineColours.length],
         backgroundColor: lineColours[index % lineColours.length],
         tension: 0.1,
-        pointRadius: team.data.length === 1 ? 4 : 0,
-        pointHoverRadius: team.data.length === 1 ? 4 : 0,
+        pointRadius: team.data[0].length === 1 ? 4 : 0,
+        pointHoverRadius: team.data[0].length === 1 ? 4 : 0,
       };
     });
 

--- a/apps/web/src/routes/scoreboard/+page.svelte
+++ b/apps/web/src/routes/scoreboard/+page.svelte
@@ -28,7 +28,7 @@
       value: number;
       created_at: Date;
     }[];
-    graph: [number, number][];
+    graph: [number[], number[]];
   };
 
   type ChallengeEntry = {
@@ -153,8 +153,8 @@
         last_solve: undefined,
         solves: [],
         awards: [],
-        graph: [],
-      };
+        graph: [[], []],
+      } as ScoreboardEntry;
 
     if (!apiMyTeam?.r?.data?.data) return null;
 

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -305,7 +305,7 @@ export type ScoreboardEntry = Static<typeof ScoreboardEntry>;
 export const ScoreboardEntryWithGraph = Type.Composite([
   ScoreboardEntry,
   Type.Object({
-    graph: Type.Array(Type.Tuple([Type.Number(), Type.Number()])),
+    graph: Type.Tuple([Type.Array(Type.Number()), Type.Array(Type.Number())]),
   }),
 ]);
 export type ScoreboardEntryWithGraph = Static<typeof ScoreboardEntryWithGraph>;

--- a/core/mod-auth/src/oauth_client_provider.ts
+++ b/core/mod-auth/src/oauth_client_provider.ts
@@ -110,7 +110,6 @@ export class OAuthIdentityProvider implements IdentityProvider {
     );
     await this.tokenService.invalidate("state", state);
     const provider_id = await this.getExternalId(method, accessToken);
-    console.log(provider_id, `${this.id()}:${data.name}`);
     const identity = await this.identityService.getIdentityForProvider(
       `${this.id()}:${data.name}`,
       provider_id,

--- a/core/server-core/src/util/graph.test.ts
+++ b/core/server-core/src/util/graph.test.ts
@@ -4,150 +4,134 @@ import { WindowDeltaedTimeSeriesPoints } from "./graph.ts";
 describe("WindowDeltaedTimeSeriesPoints", () => {
   describe("edge cases", () => {
     it("should return original points when windowSize is 1", () => {
-      const points: [number, number][] = [
-        [2, 10],
-        [3, 20],
-        [1, 30],
+      const points: [number[], number[]] = [
+        [2, 3, 1],
+        [10, 20, 30],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 1);
       expect(result).toEqual(points);
     });
 
     it("should return empty array when points array is empty", () => {
-      const result = WindowDeltaedTimeSeriesPoints([], 5);
-      expect(result).toEqual([]);
+      const result = WindowDeltaedTimeSeriesPoints([[], []], 5);
+      expect(result).toEqual([[], []]);
     });
 
     it("should handle single point", () => {
-      const points: [number, number][] = [[5, 100]];
+      const points: [number[], number[]] = [[5], [100]];
       const result = WindowDeltaedTimeSeriesPoints(points, 10);
-      expect(result).toEqual([[0, 100]]);
+      expect(result).toEqual([[0], [100]]);
     });
   });
 
   describe("basic windowing with default sum reducer", () => {
     it("should group points within same window", () => {
       // Window size 10: points at t=0-9 go to window 0, t=10-19 to window 10, etc.
-      const points: [number, number][] = [
-        [3, 10], // t=3, window=0
-        [4, 20], // t=7, window=0
-        [5, 30], // t=12, window=10
-        [8, 40], // t=20, window=20
+      const points: [number[], number[]] = [
+        [3, 4, 5, 8],
+        [10, 20, 30, 40],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10);
 
       // Should return deltas: [0, 30], [10, 30], [10, 40]
       expect(result).toEqual([
-        [0, 30], // window 0: sum of 10+20
-        [10, 30], // delta from 0 to 10, value 30
-        [10, 40], // delta from 10 to 20, value 40
+        [0, 10, 10],
+        [30, 30, 40],
       ]);
     });
 
     it("should handle points that span multiple windows", () => {
-      const points: [number, number][] = [
-        [5, 100], // t=5, window=0
-        [15, 200], // t=20, window=20
-        [25, 300], // t=45, window=40
+      const points: [number[], number[]] = [
+        [5, 15, 25],
+        [100, 200, 300],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10);
 
       expect(result).toEqual([
-        [0, 100], // window 0
-        [20, 200], // delta to window 20
-        [20, 300], // delta to window 40
+        [0, 20, 20],
+        [100, 200, 300],
       ]);
     });
 
     it("should accumulate values in same window with sum reducer", () => {
-      const points: [number, number][] = [
-        [1, 10], // t=1, window=0
-        [2, 20], // t=3, window=0
-        [3, 30], // t=6, window=0
-        [5, 40], // t=11, window=10
+      const points: [number[], number[]] = [
+        [1, 2, 3, 5],
+        [10, 20, 30, 40],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10);
 
       expect(result).toEqual([
-        [0, 60], // window 0: 10+20+30
-        [10, 40], // window 10: 40
+        [0, 10],
+        [60, 40],
       ]);
     });
   });
 
   describe("custom reducers", () => {
     it("should work with multiplication reducer", () => {
-      const points: [number, number][] = [
-        [2, 3], // t=2, window=0
-        [3, 4], // t=5, window=0
-        [6, 5], // t=11, window=10
+      const points: [number[], number[]] = [
+        [2, 3, 6],
+        [3, 4, 5],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10, (a, b) => a * b);
 
       expect(result).toEqual([
-        [0, 12], // window 0: 3*4
-        [10, 5], // window 10: 5
+        [0, 10],
+        [12, 5],
       ]);
     });
 
     it("should work with max reducer", () => {
-      const points: [number, number][] = [
-        [1, 100], // t=1, window=0
-        [2, 50], // t=3, window=0
-        [3, 200], // t=6, window=0
-        [5, 75], // t=11, window=10
+      const points: [number[], number[]] = [
+        [1, 2, 3, 5],
+        [100, 50, 200, 75],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10, Math.max);
 
       expect(result).toEqual([
-        [0, 200], // window 0: max(100, 50, 200)
-        [10, 75], // window 10: 75
+        [0, 10],
+        [200, 75],
       ]);
     });
 
     it("should work with min reducer", () => {
-      const points: [number, number][] = [
-        [1, 100], // t=1, window=0
-        [2, 50], // t=3, window=0
-        [3, 200], // t=6, window=0
-        [5, 25], // t=11, window=10
+      const points: [number[], number[]] = [
+        [1, 2, 3, 5],
+        [100, 50, 200, 25],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10, Math.min);
 
       expect(result).toEqual([
-        [0, 50], // window 0: min(100, 50, 200)
-        [10, 25], // window 10: 25
+        [0, 10],
+        [50, 25],
       ]);
     });
   });
 
   describe("different window sizes", () => {
     it("should work with window size 5", () => {
-      const points: [number, number][] = [
-        [2, 10], // t=2, window=0
-        [4, 20], // t=6, window=5
-        [3, 30], // t=9, window=5
+      const points: [number[], number[]] = [
+        [2, 4, 3],
+        [10, 20, 30],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 5);
 
       expect(result).toEqual([
-        [0, 10], // window 0
-        [5, 50], // window 5: 20+30
+        [0, 5],
+        [10, 50],
       ]);
     });
 
     it("should work with larger window size", () => {
-      const points: [number, number][] = [
-        [10, 100], // t=10, window=0
-        [15, 200], // t=25, window=0
-        [30, 300], // t=55, window=50
-        [20, 400], // t=75, window=50
+      const points: [number[], number[]] = [
+        [10, 15, 30, 20],
+        [100, 200, 300, 400],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 50);
 
       expect(result).toEqual([
-        [0, 300], // window 0: 100+200
-        [50, 700], // window 50: 300+400
+        [0, 50],
+        [300, 700],
       ]);
     });
   });
@@ -155,50 +139,41 @@ describe("WindowDeltaedTimeSeriesPoints", () => {
   describe("time accumulation behavior", () => {
     it("should properly accumulate time across points", () => {
       // Test that time accumulates correctly: t += p[0]
-      const points: [number, number][] = [
-        [5, 10], // t=5, window=0 (floor(5/10)*10 = 0)
-        [8, 20], // t=13, window=10 (floor(13/10)*10 = 10)
-        [2, 30], // t=15, window=10 (floor(15/10)*10 = 10)
-        [10, 40], // t=25, window=20 (floor(25/10)*10 = 20)
+      const points: [number[], number[]] = [
+        [5, 8, 2, 10],
+        [10, 20, 30, 40],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10);
 
       expect(result).toEqual([
-        [0, 10], // window 0
-        [10, 50], // window 10: 20+30
-        [10, 40], // window 20: 40
+        [0, 10, 10],
+        [10, 50, 40],
       ]);
     });
   });
 
   describe("delta calculation", () => {
     it("should return correct deltas between windows", () => {
-      const points: [number, number][] = [
-        [15, 100], // t=15, window=10
-        [25, 200], // t=40, window=40
-        [35, 300], // t=75, window=70
+      const points: [number[], number[]] = [
+        [15, 25, 35],
+        [100, 200, 300],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10);
       expect(result).toEqual([
-        [10, 100], // first window at 10
-        [30, 200], // delta from 10 to 40 = 30
-        [30, 300], // delta from 40 to 70 = 30
+        [10, 30, 30],
+        [100, 200, 300],
       ]);
     });
 
     it("should handle consecutive windows", () => {
-      const points: [number, number][] = [
-        [5, 10], // t=5, window=0
-        [8, 20], // t=13, window=10
-        [7, 30], // t=20, window=20
-        [10, 40], // t=30, window=30
+      const points: [number[], number[]] = [
+        [5, 8, 7, 10],
+        [10, 20, 30, 40],
       ];
       const result = WindowDeltaedTimeSeriesPoints(points, 10);
       expect(result).toEqual([
-        [0, 10],
-        [10, 20],
-        [10, 30],
-        [10, 40],
+        [0, 10, 10, 10],
+        [10, 20, 30, 40],
       ]);
     });
   });

--- a/core/server-core/src/util/graph.ts
+++ b/core/server-core/src/util/graph.ts
@@ -1,25 +1,29 @@
 export const WindowDeltaedTimeSeriesPoints = (
-  points: [number, number][],
+  points: [number[], number[]] | undefined,
   windowSize = 1,
   reducer = (a: number, b: number) => a + b,
-) => {
-  if (windowSize === 1 || points.length === 0) return points;
+): [number[], number[]] => {
+  if (!points) return [[], []];
+  if (points[0].length !== points[1].length) throw new Error("Invalid graph");
+  if (windowSize === 1 || points[0].length === 0) return points;
   let t = points[0][0];
   let x = Math.floor(t / windowSize) * windowSize;
   let l = 0;
-  let y = points[0][1];
-  let out: [number, number][] = [];
-  for (const p of points.slice(1)) {
-    const w = Math.floor((t += p[0]) / windowSize) * windowSize;
+  let y = points[1][0];
+  const out: [number[], number[]] = [[], []];
+  for (let p = 1; p < points[0].length; p++) {
+    const w = Math.floor((t += points[0][p]) / windowSize) * windowSize;
     if (w === x) {
-      y = reducer(y, p[1]);
+      y = reducer(y, points[1][p]);
     } else {
-      out.push([x - l, y]);
+      out[0].push(x - l);
+      out[1].push(y);
       l = x;
       x = w;
-      y = p[1];
+      y = points[1][p];
     }
   }
-  out.push([x - l, y]);
+  out[0].push(x - l);
+  out[1].push(y);
   return out;
 };


### PR DESCRIPTION
separate series of graph

instead of [[x,y], [x,y],[x,y], [x,y],[x,y]] we now have [[x,x,x,x,x],[y,y,y,y,y]]

not too much should change for the most part (it also compresses better since correlated data is next to each other)

Also have done a test to make sure i didn't troll

```
Comparing graphs between:
Old format: a.json
New format: b.json
---
Comparing 1668 entries...

=== SUMMARY ===
Total entries: 1668
Graphs compared: 1668
Matching graphs: 1668
All graphs match: true
```
