### PR TITLE
Allow attaching arbitrary URLs as files

### DIFF
--- a/apps/server/src/core.ts
+++ b/apps/server/src/core.ts
@@ -32,6 +32,7 @@ import { FILE_LOCAL_PATH, TOKEN_SECRET } from "./config.ts";
 import { RateLimitHook } from "./hooks/rate_limit.ts";
 import { NodeMailerProvider } from "@noctf/server-core/services/email/nodemailer";
 import { S3FileProvider } from "@noctf/server-core/services/file/s3";
+import { ManualFileProvider } from "@noctf/server-core/services/file/manual";
 
 export default async function (fastify: FastifyInstance) {
   fastify.addHook("preHandler", AuthnHook);
@@ -41,6 +42,7 @@ export default async function (fastify: FastifyInstance) {
   const { configService, emailService, fileService } = fastify.container.cradle;
   fileService.register(new LocalFileProvider(FILE_LOCAL_PATH, TOKEN_SECRET));
   fileService.register(new S3FileProvider());
+  fileService.register(new ManualFileProvider());
 
   emailService.register(new NodeMailerProvider({ configService }));
 

--- a/core/api/src/requests.ts
+++ b/core/api/src/requests.ts
@@ -525,3 +525,19 @@ export const AdminUpdateAppRequest = Type.Partial(
   },
 );
 export type AdminUpdateAppRequest = Static<typeof AdminUpdateAppRequest>;
+
+export const AdminCreateManualFileRequest = Type.Object({
+  files: Type.Array(
+    Type.Object(
+      {
+        filename: Type.String({ maxLength: 255, pattern: "[a-zA-Z0-9_\\-. ]+" }),
+        url: Type.String({ format: "uri" }),
+        size: Type.Integer({ minimum: 1 }),
+        hash: Type.String({ pattern: "^[0-9a-fA-F]{64}$" })
+      },
+      { additionalProperties: false },
+    )
+  )
+}
+);
+export type AdminCreateManualFileRequest = Static<typeof AdminCreateManualFileRequest>;

--- a/core/api/src/responses.ts
+++ b/core/api/src/responses.ts
@@ -232,6 +232,14 @@ export type AdminFileMetadataResponse = Static<
   typeof AdminFileMetadataResponse
 >;
 
+export const AdminManualFileMetadataResponse = Type.Object({
+  data: Type.Array(FileMetadata),
+});
+export type AdminManualFileMetadataResponse = Static<
+  typeof AdminManualFileMetadataResponse
+>;
+
+
 export const AdminGetChallengeResponse = Type.Object({
   data: Challenge,
 });

--- a/core/server-core/src/services/file/manual.ts
+++ b/core/server-core/src/services/file/manual.ts
@@ -1,0 +1,32 @@
+import { FileMetadata } from "@noctf/api/datatypes";
+import { Readable } from "stream";
+import {
+  FileProvider,
+  FileProviderInstance,
+} from "./types.ts";
+
+export class ManualFileProvider implements FileProvider<ManualFileProviderInstance> {
+  name = "manual";
+
+  getInstance() {
+    return new ManualFileProviderInstance();
+  }
+
+  getSchema(): null {
+    return null;
+  }
+}
+
+export class ManualFileProviderInstance implements FileProviderInstance {
+  constructor() {}
+
+  async delete(ref: string): Promise<void> {}
+
+  async getURL(ref: string): Promise<string> {
+    return ref;
+  }
+
+  async download(): Promise<[Readable, Omit<FileMetadata, "url">]> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/core/server-core/src/services/file/types.ts
+++ b/core/server-core/src/services/file/types.ts
@@ -14,7 +14,7 @@ export interface FileProvider<T extends FileProviderInstance> {
 }
 
 export interface FileProviderInstance {
-  upload(rs: Readable, pm: Omit<ProviderFileMetadata, "size">): Promise<string>;
+  upload?(rs: Readable, pm: Omit<ProviderFileMetadata, "size">): Promise<string>;
   delete(ref: string): Promise<void>;
   getURL(ref: string): Promise<string>;
   download(


### PR DESCRIPTION
This PR adds a file provider that allows attaching arbitrary URLs as files. This is useful in a few situations, for example:
  - For linking to e.g. google drive/dropbox for very large files
  - For using additional access control, logging etc
  - For offloading file hosting to a free service e.g. github releases

I've modified the `FileProviderInstance` type to make the `upload` method optional. This means that file providers can now effectively be read-only (from the perspective of the file service).

I also added an API endpoint for uploading manual URL files, and updated the challenge creation/modification UI:
<img width="1590" height="480" alt="image" src="https://github.com/user-attachments/assets/fb65a558-e822-4962-99d1-66b302006b0c" />
<img width="604" height="650" alt="image" src="https://github.com/user-attachments/assets/831a6fb0-e8a0-40e2-ac8e-24fbd261c889" />

