### PR TITLE
Update noctfcli flag strategies to use regex_sensitive/regex_insensitive

### DIFF
--- a/tools/noctfcli/src/noctfcli/models.py
+++ b/tools/noctfcli/src/noctfcli/models.py
@@ -11,7 +11,8 @@ class FlagStrategy(str, Enum):
 
     CASE_SENSITIVE = "case_sensitive"
     CASE_INSENSITIVE = "case_insensitive"
-    REGEX = "regex"
+    REGEX_SENSITIVE = "regex_sensitive"
+    REGEX_INSENSITIVE = "regex_insensitive"
 
 
 class SolveInputType(str, Enum):

--- a/tools/noctfcli/src/noctfcli/schema/noctf.yaml.schema.json
+++ b/tools/noctfcli/src/noctfcli/schema/noctf.yaml.schema.json
@@ -65,7 +65,7 @@
               },
               "strategy": {
                 "type": "string",
-                "enum": ["case_sensitive", "case_insensitive", "regex"],
+                "enum": ["case_sensitive", "case_insensitive", "regex_sensitive", "regex_insensitive"],
                 "default": "case_sensitive",
                 "description": "Flag matching strategy"
               }


### PR DESCRIPTION
`noctfcli` currently doesn't work with regex flags since its schema only allows `strategy: regex`, whilst the server only allows `regex_sensitive` or `regex_insensitive`. This PR fixes this by swapping `regex` for `regex_sensitive` and `regex_insensitive` in the noctfcli schema and models.

I considered setting up `regex` as an alias for `regex_sensitive` for backwards compatibility, but since this has been broken for some time already I think it's fine to break compatibility.