### PR TITLE
Allow flag placeholder to be configured in SetupConfig

### DIFF
--- a/apps/server/src/routes/admin_setup.ts
+++ b/apps/server/src/routes/admin_setup.ts
@@ -11,7 +11,7 @@ export async function routes(fastify: FastifyInstance) {
       active: false,
       name: "noCTF",
       root_url: "http://localhost:5173",
-      flag_prefix: "noCTF"
+      flag_prefix: "noCTF",
       allow_late_submissions: false,
     },
     ({ initialized, end_time_s, freeze_time_s }) => {

--- a/apps/server/src/routes/admin_setup.ts
+++ b/apps/server/src/routes/admin_setup.ts
@@ -11,6 +11,7 @@ export async function routes(fastify: FastifyInstance) {
       active: false,
       name: "noCTF",
       root_url: "http://localhost:5173",
+      flag_prefix: "noCTF"
       allow_late_submissions: false,
     },
     ({ initialized, end_time_s, freeze_time_s }) => {

--- a/apps/web/src/lib/components/challenges/ChallengeInfo.svelte
+++ b/apps/web/src/lib/components/challenges/ChallengeInfo.svelte
@@ -33,6 +33,7 @@
   import { toasts } from "$lib/stores/toast";
   import DifficultyChip from "./DifficultyChip.svelte";
   import authState from "$lib/state/auth.svelte";
+  import configState from "$lib/state/config.svelte";
   import { goto } from "$app/navigation";
 
   let { challData, challDetails, loading, onSolve }: ChallengeInfoProps =
@@ -243,7 +244,7 @@
             }}
             type="text"
             disabled={["correct", "submitting"].includes(flagSubmitStatus)}
-            placeholder={"noCTF{...}"}
+            placeholder={(configState.siteConfig?.flag_prefix || "noCTF") + "{...}"}
             required
             class={"w-full input input-bordered flex-grow pop duration-200 transition-colors focus:outline-none focus:pop focus:ring-0 focus:ring-offset-0 " +
               (flagSubmitStatus == "incorrect"

--- a/core/api/src/config.ts
+++ b/core/api/src/config.ts
@@ -105,6 +105,11 @@ export const SetupConfig = Type.Object(
     end_time_s: Type.Optional(
       Type.Integer({ title: "CTF End Time (Epoch seconds)", minimum: 0 }),
     ),
+    flag_prefix: Type.String({
+      title: "Flag Prefix",
+      description:
+        "Prefix for all flags in the CTF.",
+    }),
     freeze_time_s: Type.Optional(
       Type.Integer({
         title: "CTF Freeze Time (Epoch seconds)",


### PR DESCRIPTION
Flag placeholder for each challenge is currently hard coded to `noCTF{...}`, and you have to manually change the source code to customise the placeholder to your own prefix.

This PR adds `flag_prefix` as a `config.setup` field, with `noCTF` being the default prefix. This change only affects the front-end. 