### PR TITLE
[submissions] add dedicated immutable submission_log table

### DIFF
--- a/apps/migrator/src/migrations/1781316381821_submission_log.ts
+++ b/apps/migrator/src/migrations/1781316381821_submission_log.ts
@@ -1,0 +1,88 @@
+import { sql, type Kysely } from "kysely";
+import { CreateTableWithDefaultTimestamps } from "../util";
+import { jsonBuildObject } from "kysely/helpers/postgres";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  const schema = db.schema;
+  await CreateTableWithDefaultTimestamps(schema, "submission_log", [
+    "created_at",
+  ])
+    .addColumn("id", "bigint", (col) =>
+      col.primaryKey().generatedByDefaultAsIdentity(),
+    )
+    .addColumn("submission_id", "integer", (col) =>
+      col.references("submission.id").onDelete("cascade"),
+    )
+    .addColumn("actor", "varchar(64)", (col) => col.notNull())
+    .addColumn("comments", "text", (col) => col.notNull().defaultTo(""))
+    .addColumn("changes", "jsonb", (col) => col.notNull().defaultTo("{}"))
+    .execute();
+
+  await schema
+    .createIndex("submission_log_idx_created_at")
+    .on("submission_log")
+    .expression(sql`created_at`)
+    .execute();
+  await schema
+    .createIndex("submission_log_idx_submission_id_created_at")
+    .on("submission_log")
+    .expression(sql`submission_id, created_at DESC`)
+    .execute();
+  await schema
+    .createIndex("submission_log_idx_actor_created_at")
+    .on("submission_log")
+    .expression(sql`actor, created_at DESC`)
+    .execute();
+
+  // move comments into submission_logs
+  await db
+    .insertInto("submission_log")
+    .columns(["submission_id", "created_at", "actor", "comments", "changes"])
+    .expression((e) =>
+      e.selectFrom("submission").select([
+        "id",
+        "updated_at",
+        sql<string>`'user:' || ${e.ref("user_id")}`.as("actor"),
+        "comments",
+        jsonBuildObject({
+          status: e.ref("status"),
+          hidden: e.ref("hidden"),
+          value: e.ref("value"),
+        }).as("changes"),
+      ]),
+    )
+    .execute();
+  await schema.alterTable("submission").dropColumn("comments").execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  const schema = db.schema;
+
+  await schema
+    .alterTable("submission")
+    .addColumn("comments", "text", (col) => col.notNull().defaultTo(""))
+    .execute();
+
+  // restore the latest comment into the submission_log table, disable triggers
+  // so the updated_at timestamp doesn't change.
+  // we don't need to unset this as the whole migration is run in a transaction
+  await sql`SET LOCAL session_replication_role = 'replica'`.execute(db);
+  await db
+    .updateTable("submission")
+    .from((eb) =>
+      eb
+        .selectFrom("submission_log")
+        .distinctOn("submission_id")
+        .select(["submission_id", "comments"])
+        .orderBy("submission_id")
+        .orderBy("created_at", "desc")
+        .as("latest_log"),
+    )
+    .set((eb) => ({
+      comments: eb.ref("latest_log.comments"),
+    }))
+    .whereRef("submission.id", "=", "latest_log.submission_id")
+    .execute();
+
+  await schema.dropTable("submission_log").execute();
+}

--- a/apps/server/src/routes/admin_submission.ts
+++ b/apps/server/src/routes/admin_submission.ts
@@ -55,13 +55,10 @@ export async function routes(fastify: FastifyInstance) {
       },
     },
     async (request) => ({
-      data: await submissionService.update(request.body, {
-        actor: {
-          type: ActorType.USER,
-          id: request.user?.id,
-        },
-        message: "Updated by admin",
-      }),
+      data: await submissionService.update(
+        request.body,
+        `user:${request.user?.id}`,
+      ),
     }),
   );
 }

--- a/apps/web/src/lib/components/SubmissionsTable.svelte
+++ b/apps/web/src/lib/components/SubmissionsTable.svelte
@@ -8,7 +8,6 @@
     team_id: number;
     challenge_id: number;
     data: string;
-    comments: string;
     source: string;
     hidden: boolean;
     value: number | null;

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -336,7 +336,6 @@ export const Submission = Type.Object({
   team_id: Type.Number(),
   challenge_id: Type.Number(),
   data: Type.String({ maxLength: 512 }),
-  comments: Type.String({ maxLength: 512 }),
   source: Type.String({ maxLength: 64 }),
   hidden: Type.Boolean(),
   value: Type.Union([Type.Null(), Type.Number()]),

--- a/core/server-core/src/dao/submission.ts
+++ b/core/server-core/src/dao/submission.ts
@@ -74,7 +74,6 @@ export class SubmissionDAO {
   async bulkUpdate(
     ids: number[],
     params: {
-      comments?: string;
       hidden?: boolean;
       value?: number | null;
       status?: SubmissionStatus;
@@ -94,9 +93,6 @@ export class SubmissionDAO {
         "status",
         GetSeq(eb).as("seq"),
       ]);
-    if (typeof params.comments === "string") {
-      query = query.set("comments", params.comments);
-    }
     if (typeof params.hidden === "boolean") {
       query = query.set("hidden", params.hidden);
     }
@@ -193,7 +189,6 @@ export class SubmissionDAO {
         "team_id",
         "challenge_id",
         "data",
-        "comments",
         "source",
         "hidden",
         "value",

--- a/core/server-core/src/dao/submission_log.ts
+++ b/core/server-core/src/dao/submission_log.ts
@@ -1,0 +1,17 @@
+import { DB } from "@noctf/schema";
+import { DBType } from "../clients/database.ts";
+import { Insertable } from "kysely";
+
+export class SubmissionLogDAO {
+  constructor(private readonly db: DBType) {}
+
+  async create(v: Insertable<DB["submission_log"]>[]) {
+    return await this.db
+      .insertInto("submission_log")
+      .values(v)
+      .returning(["id", "created_at"])
+      .execute();
+  }
+
+  // TODO: list
+}

--- a/core/server-core/src/services/challenge/index.ts
+++ b/core/server-core/src/services/challenge/index.ts
@@ -28,6 +28,7 @@ import { CoreChallengePlugin } from "./core_plugin.ts";
 import { LocalCache } from "../../util/local_cache.ts";
 import type { SerializableMap } from "@noctf/api/types";
 import { SubmissionStatus } from "@noctf/api/enums";
+import { SubmissionLogDAO } from "../../dao/submission_log.ts";
 
 type Props = Pick<
   ServiceCradle,
@@ -44,6 +45,7 @@ const SLUG_REGEX = new RegExp(Slug.format!);
 export class ChallengeService {
   private readonly logger;
   private readonly auditLogService;
+  private readonly databaseClient;
   private readonly eventBusService;
   private readonly challengeDAO;
   private readonly submissionDAO;
@@ -75,6 +77,7 @@ export class ChallengeService {
   }: Props) {
     this.logger = logger;
     this.auditLogService = auditLogService;
+    this.databaseClient = databaseClient;
     this.eventBusService = eventBusService;
 
     this.challengeDAO = new ChallengeDAO(databaseClient.get());
@@ -232,17 +235,31 @@ export class ChallengeService {
       );
       const solved = state.status === "correct";
       const { id, created_at, updated_at, seq } =
-        await this.submissionDAO.create({
-          team_id: teamId,
-          user_id: userId,
-          challenge_id: challenge.id,
-          source: challenge.private_metadata.solve.source,
-          data,
-          status: state.status,
-          comments: state.comment,
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          metadata: metadata as any,
+        await this.databaseClient.transaction(async (tx) => {
+          const submissionDAO = new SubmissionDAO(tx);
+          const logDAO = new SubmissionLogDAO(tx);
+          const result = await submissionDAO.create({
+            team_id: teamId,
+            user_id: userId,
+            challenge_id: challenge.id,
+            source: challenge.private_metadata.solve.source,
+            data,
+            status: state.status,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            metadata: metadata as any,
+          });
+
+          await logDAO.create([
+            {
+              actor_id: userId,
+              comments: state.comment,
+              submission_id: result.id,
+              changes: { status: state.status, hidden: false },
+            },
+          ]);
+          return result;
         });
+
       await this.eventBusService.publish(SubmissionUpdateEvent, {
         id,
         challenge_id: challenge.id,

--- a/core/server-core/src/services/file/external.ts
+++ b/core/server-core/src/services/file/external.ts
@@ -1,10 +1,7 @@
 import { ExternalFile, FileMetadata } from "@noctf/api/datatypes";
 import { Readable } from "stream";
 import type { FileProviderInstance, ProviderFileMetadata } from "./types.ts";
-import {
-  BadRequestError,
-  NotImplementedError,
-} from "../../errors.ts";
+import { BadRequestError, NotImplementedError } from "../../errors.ts";
 import { TypeCompiler } from "@sinclair/typebox/compiler";
 
 // The practical limit of a URL is around 2048 bytes

--- a/core/server-core/src/services/submission.ts
+++ b/core/server-core/src/services/submission.ts
@@ -4,19 +4,18 @@ import { SubmissionDAO } from "../dao/submission.ts";
 import { AuditParams } from "../types/audit_log.ts";
 import { SubmissionUpdateEvent } from "@noctf/api/events";
 import { SubmissionStatus } from "@noctf/api/enums";
+import { SubmissionLogDAO } from "../dao/submission_log.ts";
+import { FilterUndefined } from "../util/filter.ts";
 
-type Props = Pick<
-  ServiceCradle,
-  "auditLogService" | "databaseClient" | "eventBusService"
->;
+type Props = Pick<ServiceCradle, "databaseClient" | "eventBusService">;
 export class SubmissionService {
   private readonly dao;
 
-  private readonly auditLogService;
+  private readonly databaseClient;
   private readonly eventBusService;
 
-  constructor({ databaseClient, auditLogService, eventBusService }: Props) {
-    this.auditLogService = auditLogService;
+  constructor({ databaseClient, eventBusService }: Props) {
+    this.databaseClient = databaseClient;
     this.eventBusService = eventBusService;
     this.dao = new SubmissionDAO(databaseClient.get());
   }
@@ -48,16 +47,24 @@ export class SubmissionService {
     return this.dao.getCount(params);
   }
 
-  async update(r: AdminUpdateSubmissionsRequest, audit?: AuditParams) {
-    const { ids, ...rest } = r;
-    const updates = await this.dao.bulkUpdate(ids, rest);
-    if (updates.length > 0)
-      await this.auditLogService.log({
-        operation: "submission.update",
-        entities: updates.map(({ id }) => `submission:${id}`),
-        actor: audit?.actor,
-        data: audit?.message,
-      });
+  async update(r: AdminUpdateSubmissionsRequest, actor: string) {
+    const { ids, comments, ...rest } = r;
+    const updates = await this.databaseClient.transaction(async (tx) => {
+      const submissionDAO = new SubmissionDAO(tx);
+      const updates = await submissionDAO.bulkUpdate(ids, rest);
+      if (updates.length > 0) {
+        const logDAO = new SubmissionLogDAO(tx);
+        await logDAO.create(
+          updates.map((u) => ({
+            comments,
+            submission_id: u.id,
+            actor,
+            changes: FilterUndefined(rest),
+          })),
+        );
+      }
+      return updates;
+    });
 
     // The DB returns the same seq if we update multiple records for the
     // same challenge to correct at the same time.
@@ -90,7 +97,7 @@ export class SubmissionService {
         hidden,
         seq: status === "correct" ? seq + vSeq : 0,
         is_update: true,
-        comments: rest.comments || "",
+        comments: comments || "",
       });
     }
     return updates.map(({ id }) => id);


### PR DESCRIPTION
This architectural change decouples submission metadata and history from the primary `submission` table, moving it into a dedicated `submission_log`.

## Why

   * This sets the stage for future performance optimizations. We intend to use the submission_log to fetch only the rows affected by changes (deltas) during score calculations, rather than scanning the entire `submission` table.
     * We make the assumption that rows in `submission` can only be added or updated, never deleted. Rows in `submission_log` are immutable once added.
   * The general `audit_log` table is reserved for high-level admin actions. Moving submission-specific history to its own table prevents the `audit_log` from being overloaded with frequent submission updates.
   * Service Accounts: By having a dedicated log, we avoid "polluting" the primary audit trail when service accounts or automated processes perform bulk updates or edits on submissions.

## Key Changes

   * Schema Migration: Introduced the `submission_log` table (tracking actor, comments, and changes via JSONB) and migrated existing comments from the submission
     table.
   * History Tracking: All submission updates (including status changes and admin edits) are now atomically logged within a transaction.
   * DAO & Service Refactoring:
       * Refactored SubmissionService and ChallengeService to handle unified logging.
       * Removed the deprecated comments column from the submission schema and API types.

## Migration Details
  The migration (1781316381821_submission_log.ts) handles the data transfer:
   * Up: Maps current submission comments and state into initial log entries.
   * Down: Restores the most recent comment from the log back to the submission table to ensure zero data loss on rollback.