### PR TITLE
Add hints to challenge API

### DIFF
--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -159,6 +159,7 @@ export const ChallengePrivateMetadataBase = Type.Object(
         { additionalProperties: false },
       ),
     ),
+    hints: Type.Optional(Type.Array(Type.String())),
   },
   { additionalProperties: true },
 );
@@ -180,6 +181,7 @@ export const ChallengePublicMetadataBase = Type.Object(
         is_attachment: Type.Boolean(),
       }),
     ),
+    hints: Type.Array(Type.String()),
   },
   { additionalProperties: true },
 );

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -123,12 +123,10 @@ export enum ChallengeSolveInputType {
 
 export const ChallengeHint = Type.Object({
   title: Type.String({ maxLength: 256 }),
-  description: Type.String()
+  description: Type.String(),
 });
 
-export type ChallengeHint = Static<
-  typeof ChallengeHint
->;
+export type ChallengeHint = Static<typeof ChallengeHint>;
 
 export const ChallengePrivateMetadataBase = Type.Object(
   {

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -120,6 +120,16 @@ export enum ChallengeSolveInputType {
   TextArea = "textarea",
   None = "none",
 }
+
+export const ChallengeHint = Type.Object({
+  title: Type.String({ maxLength: 256 }),
+  description: Type.String()
+});
+
+export type ChallengeHint = Static<
+  typeof ChallengeHint
+>;
+
 export const ChallengePrivateMetadataBase = Type.Object(
   {
     solve: Type.Object(
@@ -159,7 +169,7 @@ export const ChallengePrivateMetadataBase = Type.Object(
         { additionalProperties: false },
       ),
     ),
-    hints: Type.Optional(Type.Array(Type.String())),
+    hints: Type.Optional(Type.Array(ChallengeHint)),
   },
   { additionalProperties: true },
 );
@@ -181,7 +191,7 @@ export const ChallengePublicMetadataBase = Type.Object(
         is_attachment: Type.Boolean(),
       }),
     ),
-    hints: Type.Array(Type.String()),
+    hints: Type.Array(ChallengeHint),
   },
   { additionalProperties: true },
 );

--- a/core/server-core/src/services/challenge/core_plugin.ts
+++ b/core/server-core/src/services/challenge/core_plugin.ts
@@ -138,6 +138,7 @@ export class CoreChallengePlugin implements ChallengePlugin {
           })
           .filter((v): v is Exclude<typeof v, null> => !!v),
       ),
+      hints: m.hints || [],
     };
   };
 

--- a/tools/noctfcli/src/noctfcli/client.py
+++ b/tools/noctfcli/src/noctfcli/client.py
@@ -403,6 +403,7 @@ class NoCTFClient:
                 "files": [
                     {"id": f.id, "is_attachment": f.is_attachment} for f in files
                 ],
+                "hints": config.hints,
             },
         }
 

--- a/tools/noctfcli/src/noctfcli/models.py
+++ b/tools/noctfcli/src/noctfcli/models.py
@@ -158,6 +158,12 @@ class ChallengeFileAttachment(BaseModel):
     is_attachment: bool = Field(..., description="Whether file is an attachment")
 
 
+class ChallengeHint(BaseModel):
+    """Challenge hint."""
+    title: str = Field(..., description="Hint title")
+    description: str = Field(..., description="Hint text (markdown)")
+
+
 class Challenge(BaseModel):
     """Full challenge data from API."""
 
@@ -190,7 +196,7 @@ class Challenge(BaseModel):
         return [Flag(**flag_data) for flag_data in flags_data]
     
     @property
-    def hints(self) -> list[str]:
+    def hints(self) -> list[ChallengeHint]:
         """Get challenge hints."""
         return self.private_metadata.get("hints", [])
 

--- a/tools/noctfcli/src/noctfcli/models.py
+++ b/tools/noctfcli/src/noctfcli/models.py
@@ -86,6 +86,7 @@ class ChallengeConfig(BaseModel):
         default_factory=list,
         description="Challenge files: local path strings or external references",
     )
+    hints: list[str] = Field(default_factory=list, description="Challenge hints")
     hidden: bool = Field(default=False, description="Whether challenge is hidden")
     visible_at: Optional[datetime] = Field(
         default=None,
@@ -187,6 +188,11 @@ class Challenge(BaseModel):
         solve_data = self.private_metadata.get("solve", {})
         flags_data = solve_data.get("flag", [])
         return [Flag(**flag_data) for flag_data in flags_data]
+    
+    @property
+    def hints(self) -> list[str]:
+        """Get challenge hints."""
+        return self.private_metadata.get("hints", [])
 
 
 class ChallengeSummary(BaseModel):

--- a/tools/noctfcli/src/noctfcli/models.py
+++ b/tools/noctfcli/src/noctfcli/models.py
@@ -86,7 +86,7 @@ class ChallengeConfig(BaseModel):
         default_factory=list,
         description="Challenge files: local path strings or external references",
     )
-    hints: list[str] = Field(default_factory=list, description="Challenge hints")
+    hints: list[ChallengeHint] = Field(default_factory=list, description="Challenge hints")
     hidden: bool = Field(default=False, description="Whether challenge is hidden")
     visible_at: Optional[datetime] = Field(
         default=None,

--- a/tools/noctfcli/src/noctfcli/schema/noctf.yaml.schema.json
+++ b/tools/noctfcli/src/noctfcli/schema/noctf.yaml.schema.json
@@ -164,8 +164,18 @@
     "hints": {
       "type": "array",
       "items": {
-        "type": "string",
-        "description": "Hint text (markdown)"
+        "type": "object",
+        "properties": {
+          "title": {
+            "type":"string",
+            "maxLength": 256,
+            "description": "Hint title"
+          },
+          "description": {
+            "type": "string",
+            "description": "Hint text (markdown)"
+          }
+        }
       },
       "description": "Challenge hints"
     }

--- a/tools/noctfcli/src/noctfcli/schema/noctf.yaml.schema.json
+++ b/tools/noctfcli/src/noctfcli/schema/noctf.yaml.schema.json
@@ -8,7 +8,7 @@
     "version": {
       "type": "string",
       "description": "Schema version",
-      "default": "1.0"
+      "default": "1.0.1"
     },
     "slug": {
       "type": "string",
@@ -160,6 +160,14 @@
     "connection_info": {
       "type": "string",
       "description": "Connection information string"
+    },
+    "hints": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Hint text (markdown)"
+      },
+      "description": "Challenge hints"
     }
   },
   "additionalProperties": true


### PR DESCRIPTION
This PR adds support for hints on the backend. I've chosen to keep hints as a simple list of strings without unlock costs for now since unlockable hints are easily abused and would add a lot of complexity here.

Closes #62. The corresponding frontend implementation is in #290.