### PR TITLE
Force each category to be on a new row

### DIFF
--- a/apps/web/src/routes/challenges/+page.svelte
+++ b/apps/web/src/routes/challenges/+page.svelte
@@ -214,10 +214,10 @@
         />
       </div>
 
-      <div class="flex flex-wrap gap-6 h-fit">
+      <div class="flex flex-col gap-6 h-fit w-full">
         {#if challenges !== undefined && Object.keys(challengesByCategory).length > 0}
           {#each Object.entries(challengesByCategory) as [category, categoryChallenges] (category)}
-            <div class="flex flex-col gap-2">
+            <div class="flex flex-col gap-2 w-full">
               <h1
                 class="text-2xl text-center w-full md:text-left p-3 rounded font-bold top-0 py-2 z-10"
               >


### PR DESCRIPTION
Currently when categories don't have many challenges each, challenges from multiple categories can show up on the same row in the jeopardy board. This is quite confusing as it's hard to tell which challs belong to each category.

<img width="822" height="537" alt="image" src="https://github.com/user-attachments/assets/5f4fec88-517f-4689-937c-05d7b2029adb" />

This PR instead forces each category to be on a new row, which is (in my opinion) much more readable.

<img width="532" height="860" alt="image" src="https://github.com/user-attachments/assets/aaf00c26-1926-4bcf-99b8-bbbddaf86ea9" />