### PR TITLE
[submissions] add weighted challenges

### DIFF
--- a/apps/migrator/src/migrations/1782716166305_submission_weight.ts
+++ b/apps/migrator/src/migrations/1782716166305_submission_weight.ts
@@ -1,0 +1,14 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  const schema = db.schema;
+  await schema
+    .alterTable("submission")
+    .addColumn("weight", "integer", (c) => c.notNull().defaultTo(0))
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  const schema = db.schema;
+  await schema.alterTable("submission").dropColumn("weight").execute();
+}

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -160,6 +160,7 @@ export const ChallengePrivateMetadataBase = Type.Object(
       {
         params: Type.Record(Type.String(), Type.Number()),
         strategy: Type.String(),
+        is_weighted: Type.Boolean(),
         bonus: Type.Optional(Type.Array(Type.Number())),
       },
       { additionalProperties: false },
@@ -355,6 +356,7 @@ export const Submission = Type.Object({
   source: Type.String({ maxLength: 64 }),
   hidden: Type.Boolean(),
   value: NullableInteger(),
+  weight: Type.Integer(),
   status: SubmissionStatus,
   created_at: TypeDate,
   updated_at: TypeDate,

--- a/core/api/src/requests.ts
+++ b/core/api/src/requests.ts
@@ -251,7 +251,9 @@ export const AdminUpdateSubmissionsRequest = Type.Object(
           id: Type.Integer(),
           comments: Type.Optional(Type.String({ maxLength: 512 })),
         }),
-        Type.Partial(Type.Pick(Submission, ["status", "hidden", "value"])),
+        Type.Partial(
+          Type.Pick(Submission, ["status", "hidden", "value", "weight"]),
+        ),
       ]),
       { minItems: 1, maxItems: 1000 },
     ),

--- a/core/server-core/src/dao/submission.ts
+++ b/core/server-core/src/dao/submission.ts
@@ -17,6 +17,7 @@ export type RawSolve = Pick<
   | "created_at"
   | "updated_at"
   | "value"
+  | "weight"
 >;
 
 const GetSeq = (eb: ExpressionBuilder<DB, "submission">) =>
@@ -75,8 +76,9 @@ export class SubmissionDAO {
     values: {
       id: number;
       hidden?: boolean;
-      value?: number | null;
+      weight?: number;
       status?: SubmissionStatus;
+      value?: number | null;
     }[],
   ): Promise<
     (Pick<
@@ -96,6 +98,7 @@ export class SubmissionDAO {
         (v) => sql`(
         ${sql.val(v.id)}::integer,
         ${sql.val(v.hidden)}::boolean,
+        ${sql.val(v.weight)}::integer,
         ${sql.val(v.status)}::submission_status,
         ${sql.val(v.value)}::integer,
         ${sql.val(!!v.value || v.value === 0 || v.value === null)}::boolean
@@ -106,11 +109,12 @@ export class SubmissionDAO {
       .updateTable("submission")
       .from(
         sql`(VALUES ${vs})`.as<"v">(
-          sql`v(id, hidden, status, value, update_value)`,
+          sql`v(id, hidden, weight, status, value, update_value)`,
         ),
       )
       .set((eb) => ({
         hidden: sql`COALESCE(v.hidden, ${eb.ref("submission.hidden")})`,
+        weight: sql`COALESCE(v.weight, ${eb.ref("submission.weight")})`,
         status: sql`COALESCE(v.status, ${eb.ref("submission.status")})`,
         value: sql`CASE 
           WHEN v.update_value = TRUE THEN v.value
@@ -219,6 +223,7 @@ export class SubmissionDAO {
         "source",
         "hidden",
         "value",
+        "weight",
         "status",
         "created_at",
         "updated_at",
@@ -258,6 +263,7 @@ export class SubmissionDAO {
         "s.created_at as created_at",
         "s.updated_at as updated_at",
         "s.value as value",
+        "s.weight as weight",
       ])
       .where("s.status", "=", "correct")
       .orderBy("s.created_at", params?.sort || "asc");

--- a/core/server-core/src/services/scoreboard/calc.test.ts
+++ b/core/server-core/src/services/scoreboard/calc.test.ts
@@ -235,6 +235,7 @@ describe(ComputeScoreboard, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -245,6 +246,7 @@ describe(ComputeScoreboard, () => {
             team_id: 2,
             user_id: 2,
             value: 100,
+            weight: 0,
           },
         ],
       ],
@@ -375,6 +377,7 @@ describe(ComputeScoreboard, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -385,6 +388,7 @@ describe(ComputeScoreboard, () => {
             team_id: 3,
             user_id: 3,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -395,6 +399,7 @@ describe(ComputeScoreboard, () => {
             team_id: 2,
             user_id: 2,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -537,6 +542,7 @@ describe(ComputeScoreboard, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -642,6 +648,589 @@ describe(ComputeScoreboard, () => {
       ]),
     });
   });
+
+  it("Weighted challenge: each solve scored by its own weight", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+      ) => number,
+    ).mockImplementation((_expr, _params, n) => n * 10);
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1) as unknown as Timestamp & Date,
+            updated_at: new Date(1) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 10,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2) as unknown as Timestamp & Date,
+            updated_at: new Date(2) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 50,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 3,
+            created_at: new Date(3) as unknown as Timestamp & Date,
+            updated_at: new Date(3) as unknown as Timestamp & Date,
+            team_id: 3,
+            user_id: 3,
+            value: null,
+            weight: 80,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+        [3, { id: 3, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+    );
+    expect(result.scoreboard).toEqual([
+      expect.objectContaining({
+        team_id: 3,
+        score: 800,
+        rank: 1,
+        solves: [
+          expect.objectContaining({
+            challenge_id: 2,
+            value: 800,
+            hidden: false,
+            bonus: undefined,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        team_id: 2,
+        score: 500,
+        rank: 2,
+        solves: [
+          expect.objectContaining({
+            challenge_id: 2,
+            value: 500,
+            hidden: false,
+            bonus: undefined,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        team_id: 1,
+        score: 100,
+        rank: 3,
+        solves: [
+          expect.objectContaining({
+            challenge_id: 2,
+            value: 100,
+            hidden: false,
+            bonus: undefined,
+          }),
+        ],
+      }),
+    ]);
+    expect(result.challenges.get(2)?.value).toBe(0);
+    expect(EvaluateScoringExpression).toHaveBeenCalledTimes(3);
+  });
+
+  it("Weighted challenge: value overrides bypass weight calculation", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+      ) => number,
+    ).mockReturnValue(500);
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1) as unknown as Timestamp & Date,
+            updated_at: new Date(1) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 50,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2) as unknown as Timestamp & Date,
+            updated_at: new Date(2) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: 200,
+            weight: 99,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+    );
+    expect(result.scoreboard).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          team_id: 1,
+          score: 500,
+        }),
+        expect.objectContaining({
+          team_id: 2,
+          score: 200,
+        }),
+      ]),
+    );
+    expect(EvaluateScoringExpression).toHaveBeenCalledTimes(1);
+  });
+
+  it("Weighted challenge: bonuses go to top-scoring eligible solves by rank", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+      ) => number,
+    ).mockImplementation((_expr, _params, n) => n * 10);
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+          bonus: [50, 25],
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1) as unknown as Timestamp & Date,
+            updated_at: new Date(1) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 80,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2) as unknown as Timestamp & Date,
+            updated_at: new Date(2) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 50,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 3,
+            created_at: new Date(3) as unknown as Timestamp & Date,
+            updated_at: new Date(3) as unknown as Timestamp & Date,
+            team_id: 3,
+            user_id: 3,
+            value: null,
+            weight: 10,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+        [3, { id: 3, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+    );
+    expect(result.scoreboard).toEqual([
+      expect.objectContaining({
+        team_id: 1,
+        score: 850,
+        rank: 1,
+        solves: [
+          expect.objectContaining({
+            value: 850,
+            bonus: 50,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        team_id: 2,
+        score: 525,
+        rank: 2,
+        solves: [
+          expect.objectContaining({
+            value: 525,
+            bonus: 25,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        team_id: 3,
+        score: 100,
+        rank: 3,
+        solves: [
+          expect.objectContaining({
+            value: 100,
+            bonus: undefined,
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("Weighted challenge: value override solves are ineligible for bonus", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+      ) => number,
+    ).mockReturnValue(500);
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+          bonus: [50],
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1) as unknown as Timestamp & Date,
+            updated_at: new Date(1) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: 999,
+            weight: 99,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2) as unknown as Timestamp & Date,
+            updated_at: new Date(2) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 50,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+    );
+    expect(result.scoreboard).toEqual([
+      expect.objectContaining({
+        team_id: 1,
+        score: 999,
+        rank: 1,
+        solves: [
+          expect.objectContaining({
+            value: 999,
+            bonus: undefined,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        team_id: 2,
+        score: 550,
+        rank: 2,
+        solves: [
+          expect.objectContaining({
+            value: 550,
+            bonus: 50,
+          }),
+        ],
+      }),
+    ]);
+  });
+
+  it("Weighted challenge: hidden teams partitioned out", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+      ) => number,
+    ).mockImplementation((_expr, _params, n) => n * 10);
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1) as unknown as Timestamp & Date,
+            updated_at: new Date(1) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 50,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2) as unknown as Timestamp & Date,
+            updated_at: new Date(2) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 80,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: ["hidden"], division_id: 1, tag_ids: [] }],
+      ]),
+      [
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+    );
+    expect(result.scoreboard).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          team_id: 1,
+          score: 500,
+          hidden: false,
+        }),
+        expect.objectContaining({
+          team_id: 2,
+          score: 0,
+          hidden: true,
+        }),
+      ]),
+    );
+    // hidden team's solve should still have been computed
+    const hiddenTeamSolve = result.challenges
+      .get(2)
+      ?.solves.find((s) => s.team_id === 2);
+    expect(hiddenTeamSolve).toEqual(
+      expect.objectContaining({
+        value: 800,
+        hidden: true,
+      }),
+    );
+  });
+
+  it("Mixed weighted and dynamic challenges in same scoreboard", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+      ) => number,
+    ).mockImplementation((_expr, _params, n) => {
+      // dynamic challenge calls with n=1 (solve count), weighted calls with weight
+      // we return n * 100 so dynamic(1)=100, weighted(30)=300
+      return n * 100;
+    });
+    const dynamicChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 1,
+    };
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1) as unknown as Timestamp & Date,
+            updated_at: new Date(1) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 0,
+          },
+        ],
+      ],
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2) as unknown as Timestamp & Date,
+            updated_at: new Date(2) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 30,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeScoreboard(
+      new Map([[1, { id: 1, flags: [], division_id: 1, tag_ids: [] }]]),
+      [
+        {
+          metadata: dynamicChallenge,
+          expr: mockDeep<Expression>(),
+        },
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+    );
+    expect(result.scoreboard).toEqual([
+      expect.objectContaining({
+        team_id: 1,
+        score: 3100,
+      }),
+    ]);
+    expect(result.challenges.get(1)?.value).toBe(100);
+    expect(result.challenges.get(2)?.value).toBe(0);
+  });
 });
 
 describe(ComputeFullGraph, () => {
@@ -708,6 +1297,7 @@ describe(ComputeFullGraph, () => {
         team_id: 1,
         title: "test",
         value: 1,
+        weight: 0,
       },
       {
         created_at: new Date(2102),
@@ -715,6 +1305,7 @@ describe(ComputeFullGraph, () => {
         team_id: 1,
         title: "test2",
         value: 5,
+        weight: 0,
       },
       {
         created_at: new Date(3234),
@@ -722,6 +1313,7 @@ describe(ComputeFullGraph, () => {
         team_id: 2,
         title: "test",
         value: 3,
+        weight: 0,
       },
     ];
     const challenges = [
@@ -743,6 +1335,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -834,6 +1427,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -844,6 +1438,7 @@ describe(ComputeFullGraph, () => {
             team_id: 2,
             user_id: 2,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -942,6 +1537,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -952,6 +1548,7 @@ describe(ComputeFullGraph, () => {
             team_id: 2,
             user_id: 2,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -967,6 +1564,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -985,6 +1583,167 @@ describe(ComputeFullGraph, () => {
       { score: 506, team_id: 1, updated_at: new Date(2102) },
     ]);
   });
+
+  it("Weighted challenge solves appear as flat deltas in graph", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+      ) => number,
+    ).mockReturnValue(500);
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const teams = new Map<number, MinimalTeamInfo>([
+      [1, { id: 1, division_id: 1, tag_ids: [], flags: [] }],
+      [2, { id: 2, division_id: 1, tag_ids: [], flags: [] }],
+    ]);
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1203) as unknown as Timestamp & Date,
+            updated_at: new Date(1203) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 50,
+          },
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2001) as unknown as Timestamp & Date,
+            updated_at: new Date(2001) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 80,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeFullGraph(
+      teams,
+      [
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+      1,
+    );
+    expect(result).toEqual([
+      { score: 500, team_id: 1, updated_at: new Date(1203) },
+      { score: 500, team_id: 2, updated_at: new Date(2001) },
+    ]);
+  });
+
+  it("Mixed weighted and dynamic challenges produce combined graph", () => {
+    vi.mocked(
+      EvaluateScoringExpression as (
+        expr: Expression,
+        params: Record<string, number>,
+        n: number,
+        all?: boolean,
+      ) => number | [number, number][],
+    ).mockImplementation((_expr, _params, _n, all) => {
+      if (all) {
+        return [
+          [2, 500],
+          [2, 400],
+        ] as [number, number][];
+      }
+      return 300;
+    });
+    const weightedChallenge: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+      private_metadata: {
+        score: {
+          params: {},
+          is_weighted: true,
+        },
+      } as Pick<
+        ChallengePrivateMetadataBase,
+        "score"
+      > as ChallengePrivateMetadataBase,
+    };
+    const teams = new Map<number, MinimalTeamInfo>([
+      [1, { id: 1, division_id: 1, tag_ids: [], flags: [] }],
+    ]);
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 0,
+          },
+        ],
+      ],
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 30,
+          },
+        ],
+      ],
+    ]);
+    const result = ComputeFullGraph(
+      teams,
+      [
+        {
+          metadata: challenge1,
+          expr: mockDeep<Expression>(),
+        },
+        {
+          metadata: weightedChallenge,
+          expr: mockDeep<Expression>(),
+        },
+      ],
+      solvesByChallenge,
+      [],
+      1,
+    );
+    expect(result).toEqual([
+      { score: 500, team_id: 1, updated_at: new Date(1000) },
+      { score: 800, team_id: 1, updated_at: new Date(2000) },
+    ]);
+  });
 });
 
 describe(PartitionSolvesByChallenge, () => {
@@ -999,6 +1758,7 @@ describe(PartitionSolvesByChallenge, () => {
       user_id: 1,
       team_id: 1,
       value: null,
+      weight: 0,
       created_at: baseDate,
       updated_at: baseDate,
       hidden: false,
@@ -1009,6 +1769,7 @@ describe(PartitionSolvesByChallenge, () => {
       user_id: 2,
       team_id: 2,
       value: null,
+      weight: 0,
       created_at: laterDate,
       updated_at: laterDate,
       hidden: false,
@@ -1019,6 +1780,7 @@ describe(PartitionSolvesByChallenge, () => {
       user_id: 1,
       team_id: 1,
       value: null,
+      weight: 0,
       created_at: earlierDate,
       updated_at: earlierDate,
       hidden: true,
@@ -1029,6 +1791,7 @@ describe(PartitionSolvesByChallenge, () => {
       user_id: 3,
       team_id: 3,
       value: null,
+      weight: 0,
       created_at: baseDate,
       updated_at: baseDate,
       hidden: false,

--- a/core/server-core/src/services/scoreboard/calc.ts
+++ b/core/server-core/src/services/scoreboard/calc.ts
@@ -42,7 +42,8 @@ export type MinimalScoreboardEntry = Pick<
   ScoreboardEntry,
   "team_id" | "score" | "updated_at" | "last_solve" | "hidden"
 >;
-function ComputeScoresForChallenge(
+
+function ComputeScoresForDynamicChallenge(
   { metadata, expr }: ChallengeMetadataWithExpr,
   teams: Map<number, MinimalTeamInfo>,
   solves: RawSolve[],
@@ -89,20 +90,91 @@ function ComputeScoresForChallenge(
     },
   );
   const rh: Solve[] = hidden.map(
-    ({ team_id, user_id, created_at, updated_at }) => {
+    ({ team_id, user_id, created_at, updated_at, value }) => {
       last_event = MaxDate(last_event, updated_at);
       return {
         team_id,
         user_id,
         challenge_id: metadata.id,
         hidden: true,
-        value: base,
+        value: value !== null ? value : base,
         created_at,
       };
     },
   );
   return {
     value: base,
+    solves: rv.concat(rh),
+    last_event: MaxDate(last_event, metadata.updated_at),
+  };
+}
+
+function ComputeScoresForWeightedChallenge(
+  { metadata, expr }: ChallengeMetadataWithExpr,
+  teams: Map<number, MinimalTeamInfo>,
+  solves: RawSolve[],
+) {
+  const {
+    score: { params, bonus },
+  } = metadata.private_metadata as ChallengePrivateMetadataBase;
+
+  const [valid, hidden] = partition(
+    solves,
+    ({ team_id, hidden }) =>
+      !(teams.get(team_id)?.flags.includes("hidden") || hidden),
+  );
+
+  let last_event = new Date(0);
+  const rv: Solve[] = valid.map(
+    ({ team_id, user_id, created_at, updated_at, value, weight }) => {
+      last_event = MaxDate(last_event, updated_at);
+      return {
+        team_id,
+        user_id,
+        challenge_id: metadata.id,
+        bonus: value === null ? 1 : undefined, // this is temporarily set to if team is eligible for bonus
+        hidden: false,
+        value:
+          value !== null
+            ? value
+            : EvaluateScoringExpression(expr, params, weight),
+        created_at,
+      };
+    },
+  );
+  rv.sort((a, b) => b.value - a.value);
+
+  // apply the bonus and unset the sentinel
+  let bonusIdx = 0;
+  for (const v of rv) {
+    if (!bonus?.[bonusIdx]) {
+      v.bonus = undefined;
+      continue;
+    }
+    if (v.bonus) {
+      v.bonus = bonus[bonusIdx++];
+      v.value += v.bonus;
+    }
+  }
+
+  const rh: Solve[] = hidden.map(
+    ({ team_id, user_id, created_at, updated_at, value, weight }) => {
+      last_event = MaxDate(last_event, updated_at);
+      return {
+        team_id,
+        user_id,
+        challenge_id: metadata.id,
+        hidden: true,
+        value:
+          value !== null
+            ? value
+            : EvaluateScoringExpression(expr, params, weight),
+        created_at,
+      };
+    },
+  );
+  return {
+    value: 0,
     solves: rv.concat(rh),
     last_event: MaxDate(last_event, metadata.updated_at),
   };
@@ -171,13 +243,34 @@ export function ComputeFullGraph(
   awards: Award[],
   sampleRateMs = 1000,
 ): HistoryDataPoint[] {
-  const stream = challenges.flatMap((x) =>
+  const [weighted, dynamic] = partition(
+    challenges,
+    (c) => c.metadata.private_metadata.score.is_weighted,
+  );
+  const dynamicStream = dynamic.flatMap((x) =>
     ComputeScoreStreamForChallenge(
       x,
       teams,
       solvesByChallenge.get(x.metadata.id) || [],
     ),
   );
+
+  // TODO: this code doesn't currently do event-by-event submission log.
+  const weightedStream = weighted.flatMap((x) =>
+    ComputeScoresForWeightedChallenge(
+      x,
+      teams,
+      solvesByChallenge.get(x.metadata.id) || [],
+    )
+      .solves.filter((x) => !x.hidden)
+      .map((x) => ({
+        team_id: x.team_id,
+        delta: x.value,
+        updated_at: x.created_at, // TODO: this is technically wrong
+      })),
+  );
+
+  const stream = dynamicStream.concat(weightedStream);
   for (const { team_id, value, created_at } of awards) {
     const hidden = teams.get(team_id)?.flags.includes("hidden");
     if (hidden) continue;
@@ -240,11 +333,20 @@ export function ComputeScoreboard(
     ]),
   );
   const computed = challenges.map((x) => {
-    const result = ComputeScoresForChallenge(
-      x,
-      teams,
-      solvesByChallenge.get(x.metadata.id) || [],
-    );
+    let result;
+    if (x.metadata.private_metadata.score.is_weighted) {
+      result = ComputeScoresForWeightedChallenge(
+        x,
+        teams,
+        solvesByChallenge.get(x.metadata.id) || [],
+      );
+    } else {
+      result = ComputeScoresForDynamicChallenge(
+        x,
+        teams,
+        solvesByChallenge.get(x.metadata.id) || [],
+      );
+    }
     return [x.metadata.id, result] as [number, ChallengeSolvesResult];
   });
   const challengeScores: ComputedChallengeScoreData[] = [];


### PR DESCRIPTION
# Add weighted challenge scoring

## Summary

Adds a new scoring mode for challenges where each submission carries its own `weight`, and the score is computed per-solve from that weight rather than from the total solve count (dynamic scoring).

This enables challenge types where different submissions can earn different amounts of points based on the quality or difficulty of their solution (think KoTH or Golf), rather than all solvers sharing a single dynamically-adjusted base score.

In practice, `weight` would typically be assigned by an external challenge backend (e.g. a grading service) that evaluates submission quality and writes back a weight via API. That API is not yet implemented — this PR lays the groundwork on the schema and scoring side.

## Changes

### Schema & API
- **Migration**: Adds `weight` integer column (default `0`) to the `submission` table
- **Datatypes**: Adds `is_weighted` boolean to challenge score metadata, `weight` integer to `Submission`
- **Requests**: Exposes `weight` in the submission review/update request schema
- **DAO**: `RawSolve` type now includes `weight`; bulk update and query methods propagate the new column

### Scoring engine (`calc.ts`)
- New `ComputeScoresForWeightedChallenge` function:
  - Calls `EvaluateScoringExpression(expr, params, weight)` per-solve instead of using a shared solve count
  - Returns `value: 0` at the challenge level (no shared base score)
  - Sorts solves by descending value, then assigns bonuses to the top-scoring *eligible* solves (those without a value override)
  - Bonus is added to the solve's value
- `ComputeScoreboard` and `ComputeFullGraph` now partition challenges by `is_weighted` and dispatch to the appropriate scoring path

### Tests (`calc.test.ts`)
8 new test cases covering:
- Per-solve weight-based scoring
- Value overrides bypassing the expression
- Rank-ordered bonus allocation
- Override solves being ineligible for bonus
- Hidden team partitioning
- Mixed weighted + dynamic challenges in the same scoreboard
- Weighted challenge graph stream generation
- Combined weighted + dynamic graph

## Known limitations
- Score history graph for weighted challenges doesn't produce event-by-event submission logs (uses solve snapshots instead)
- Graph `updated_at` uses `created_at` for weighted solves (noted in TODO)
