### PR TITLE
[submissions] add weighted challenges (attempt 2)

### DIFF
--- a/apps/migrator/src/migrations/1782716166305_submission_weight.ts
+++ b/apps/migrator/src/migrations/1782716166305_submission_weight.ts
@@ -1,0 +1,14 @@
+import type { Kysely } from "kysely";
+
+export async function up(db: Kysely<any>): Promise<void> {
+  const schema = db.schema;
+  await schema
+    .alterTable("submission")
+    .addColumn("weight", "integer", (c) => c.notNull().defaultTo(0))
+    .execute();
+}
+
+export async function down(db: Kysely<any>): Promise<void> {
+  const schema = db.schema;
+  await schema.alterTable("submission").dropColumn("weight").execute();
+}

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -355,6 +355,7 @@ export const Submission = Type.Object({
   source: Type.String({ maxLength: 64 }),
   hidden: Type.Boolean(),
   value: NullableInteger(),
+  weight: Type.Integer(),
   status: SubmissionStatus,
   created_at: TypeDate,
   updated_at: TypeDate,

--- a/core/api/src/requests.ts
+++ b/core/api/src/requests.ts
@@ -251,7 +251,9 @@ export const AdminUpdateSubmissionsRequest = Type.Object(
           id: Type.Integer(),
           comments: Type.Optional(Type.String({ maxLength: 512 })),
         }),
-        Type.Partial(Type.Pick(Submission, ["status", "hidden", "value"])),
+        Type.Partial(
+          Type.Pick(Submission, ["status", "hidden", "value", "weight"]),
+        ),
       ]),
       { minItems: 1, maxItems: 1000 },
     ),

--- a/core/server-core/src/dao/submission.ts
+++ b/core/server-core/src/dao/submission.ts
@@ -17,6 +17,7 @@ export type RawSolve = Pick<
   | "created_at"
   | "updated_at"
   | "value"
+  | "weight"
 >;
 
 const GetSeq = (eb: ExpressionBuilder<DB, "submission">) =>
@@ -75,8 +76,9 @@ export class SubmissionDAO {
     values: {
       id: number;
       hidden?: boolean;
-      value?: number | null;
+      weight?: number;
       status?: SubmissionStatus;
+      value?: number | null;
     }[],
   ): Promise<
     (Pick<
@@ -96,6 +98,7 @@ export class SubmissionDAO {
         (v) => sql`(
         ${sql.val(v.id)}::integer,
         ${sql.val(v.hidden)}::boolean,
+        ${sql.val(v.weight)}::integer,
         ${sql.val(v.status)}::submission_status,
         ${sql.val(v.value)}::integer,
         ${sql.val(!!v.value || v.value === 0 || v.value === null)}::boolean
@@ -106,11 +109,12 @@ export class SubmissionDAO {
       .updateTable("submission")
       .from(
         sql`(VALUES ${vs})`.as<"v">(
-          sql`v(id, hidden, status, value, update_value)`,
+          sql`v(id, hidden, weight, status, value, update_value)`,
         ),
       )
       .set((eb) => ({
         hidden: sql`COALESCE(v.hidden, ${eb.ref("submission.hidden")})`,
+        weight: sql`COALESCE(v.weight, ${eb.ref("submission.weight")})`,
         status: sql`COALESCE(v.status, ${eb.ref("submission.status")})`,
         value: sql`CASE 
           WHEN v.update_value = TRUE THEN v.value
@@ -219,6 +223,7 @@ export class SubmissionDAO {
         "source",
         "hidden",
         "value",
+        "weight",
         "status",
         "created_at",
         "updated_at",
@@ -258,6 +263,7 @@ export class SubmissionDAO {
         "s.created_at as created_at",
         "s.updated_at as updated_at",
         "s.value as value",
+        "s.weight as weight",
       ])
       .where("s.status", "=", "correct")
       .orderBy("s.created_at", params?.sort || "asc");

--- a/core/server-core/src/services/challenge/core_plugin.ts
+++ b/core/server-core/src/services/challenge/core_plugin.ts
@@ -145,7 +145,7 @@ export class CoreChallengePlugin implements ChallengePlugin {
   validate = async (m: ChallengePrivateMetadataBase) => {
     try {
       const expr = await this.scoreService.getExpr(m.score.strategy);
-      EvaluateScoringExpression(expr, m.score.params, 0);
+      EvaluateScoringExpression(expr, m.score.params, { n: 0, w: 0 });
     } catch (e) {
       throw new ValidationError(
         `Failed to evaluate scoring algorithm ${m.score.strategy}: ` +

--- a/core/server-core/src/services/score.ts
+++ b/core/server-core/src/services/score.ts
@@ -4,7 +4,7 @@ import type { Expression } from "expr-eval";
 import { Parser } from "expr-eval";
 import type { ServiceCradle } from "../index.ts";
 import type { ScoringStrategy } from "@noctf/api/datatypes";
-import { ValidationError } from "../errors.ts";
+import { ApplicationError, ValidationError } from "../errors.ts";
 
 type Props = Pick<ServiceCradle, "configService" | "logger">;
 
@@ -32,50 +32,25 @@ const parser = new Parser({
     assignment: false,
     concatenate: false,
     fndef: false,
+    factorial: false, // DoS vector
+    in: false,
   },
 });
 
 export function EvaluateScoringExpression(
   expr: Expression,
   params: Record<string, number>,
-  n: number,
-): number;
-export function EvaluateScoringExpression(
-  expr: Expression,
-  params: Record<string, number>,
-  n: number,
-  all: true,
-): [number, number][];
-export function EvaluateScoringExpression(
-  expr: Expression,
-  params: Record<string, number>,
-  n: number,
-  all?: boolean,
-): number | [number, number][] {
-  if (!all) {
-    return Math.round(
-      expr.evaluate({
-        ...params,
-        ctx: { n },
-      }),
-    );
-  }
-  const results: [number, number][] = [];
-  for (let i = 0; i <= n; i++) {
-    const result = Math.round(
-      expr.evaluate({
-        ...params,
-        ctx: { n: i },
-      }),
-    );
-    if (!results.length || results[results.length - 1][1] !== result) {
-      results.push([1, result]);
-    } else {
-      results[results.length - 1][0]++;
-    }
-  }
-  return results;
+  ctx: { n: number; w: number },
+): number {
+  return Math.round(
+    expr.evaluate({
+      ...params,
+      ctx,
+    }),
+  );
 }
+
+const VALID_CTX = new Set(["n", "w"]);
 
 export class ScoreService {
   private readonly configService;
@@ -94,8 +69,20 @@ export class ScoreService {
     await this.configService.register(ScoreConfig, { strategies: {} }, (v) => {
       for (const strategy of Object.keys(v.strategies)) {
         try {
-          parser.parse(v.strategies[strategy]!.expr);
+          const expr = parser.parse(v.strategies[strategy]!.expr);
+          const vars = new Set(
+            expr
+              .variables({ withMembers: true })
+              .filter((v) => v.startsWith("ctx."))
+              .map((v) => v.substring(4)),
+          );
+          if (!vars.isSubsetOf(VALID_CTX)) {
+            throw new ValidationError(
+              `Scoring strategy ${strategy} has unknown context variables`,
+            );
+          }
         } catch (e) {
+          if (e instanceof ApplicationError) throw e;
           throw new ValidationError(
             `Scoring strategy ${strategy} failed to parse`,
           );

--- a/core/server-core/src/services/scoreboard/calc.test.ts
+++ b/core/server-core/src/services/scoreboard/calc.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   ChallengeMetadataWithExpr,
   ComputeFullGraph,
@@ -22,7 +22,38 @@ import { RawSolve } from "../../dao/submission.ts";
 
 vi.mock(import("../score.ts"));
 
+function MockEvaluateSolves(series: [number, number][]) {
+  return (
+    _expr: Expression,
+    _params: Record<string, number>,
+    { n }: { n: number },
+  ) => {
+    let remain = n;
+    for (const s of series) {
+      if (remain - s[0] >= 0) {
+        remain -= s[0];
+        continue;
+      }
+      return s[1];
+    }
+    return series[series.length - 1][1];
+  };
+}
+
+function MockEvaluateSolvesWithWeight(fn: (n: number, w: number) => number) {
+  return (
+    _expr: Expression,
+    _params: Record<string, number>,
+    ctx: { n: number; w: number },
+  ) => fn(ctx.n, ctx.w);
+}
+
 describe(GetChangedTeamScores, () => {
+  const expr = mockDeep<Expression>();
+  beforeEach(() => {
+    expr.variables.mockReturnValue(["ctx.n"]);
+  });
+
   it("diff does not return any results if same everything", () => {
     const s1: ScoreboardEntry[] = [
       {
@@ -182,6 +213,10 @@ describe(GetChangedTeamScores, () => {
 });
 
 describe(ComputeScoreboard, () => {
+  const expr = mockDeep<Expression>();
+  beforeEach(() => {
+    expr.variables.mockReturnValue(["ctx.n"]);
+  });
   const challenge1: ChallengeMetadata = {
     id: 1,
     slug: "",
@@ -215,13 +250,7 @@ describe(ComputeScoreboard, () => {
   });
 
   it("Value overrides for solves do not count towards dynamic scoring", () => {
-    vi.mocked(
-      EvaluateScoringExpression as (
-        expr: Expression,
-        params: Record<string, number>,
-        n: number,
-      ) => number,
-    ).mockReturnValue(1);
+    vi.mocked(EvaluateScoringExpression).mockReturnValue(1);
     const solvesByChallenge = new Map<number, RawSolve[]>([
       [
         1,
@@ -235,6 +264,7 @@ describe(ComputeScoreboard, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -245,6 +275,7 @@ describe(ComputeScoreboard, () => {
             team_id: 2,
             user_id: 2,
             value: 100,
+            weight: 0,
           },
         ],
       ],
@@ -263,7 +294,7 @@ describe(ComputeScoreboard, () => {
               score: { ...challenge1.private_metadata.score, bonus: [2] },
             },
           },
-          expr: mockDeep<Expression>(),
+          expr,
         },
       ],
       solvesByChallenge,
@@ -345,23 +376,11 @@ describe(ComputeScoreboard, () => {
         ],
       ]),
     });
-    vi.mocked(
-      EvaluateScoringExpression as (
-        expr: Expression,
-        params: Record<string, number>,
-        n: number,
-      ) => number,
-    ).mockReturnValue(1);
+    vi.mocked(EvaluateScoringExpression).mockReturnValue(1);
   });
 
   it("Calculates challenge scores, uses the last valid solve date as the date", () => {
-    vi.mocked(
-      EvaluateScoringExpression as (
-        expr: Expression,
-        params: Record<string, number>,
-        n: number,
-      ) => number,
-    ).mockReturnValue(1);
+    vi.mocked(EvaluateScoringExpression).mockReturnValue(1);
     const solvesByChallenge = new Map<number, RawSolve[]>([
       [
         1,
@@ -375,6 +394,7 @@ describe(ComputeScoreboard, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -385,6 +405,7 @@ describe(ComputeScoreboard, () => {
             team_id: 3,
             user_id: 3,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -395,6 +416,7 @@ describe(ComputeScoreboard, () => {
             team_id: 2,
             user_id: 2,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -408,7 +430,7 @@ describe(ComputeScoreboard, () => {
       [
         {
           metadata: challenge1,
-          expr: mockDeep<Expression>(),
+          expr,
         },
       ],
       solvesByChallenge,
@@ -517,13 +539,7 @@ describe(ComputeScoreboard, () => {
   });
 
   it("Calculates challenge scores and adds awards to date", () => {
-    vi.mocked(
-      EvaluateScoringExpression as (
-        expr: Expression,
-        params: Record<string, number>,
-        n: number,
-      ) => number,
-    ).mockReturnValue(1);
+    vi.mocked(EvaluateScoringExpression).mockReturnValue(1);
     const solvesByChallenge = new Map<number, RawSolve[]>([
       [
         1,
@@ -537,6 +553,7 @@ describe(ComputeScoreboard, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -549,7 +566,7 @@ describe(ComputeScoreboard, () => {
       [
         {
           metadata: challenge1,
-          expr: mockDeep<Expression>(),
+          expr,
         },
       ],
       solvesByChallenge,
@@ -645,6 +662,11 @@ describe(ComputeScoreboard, () => {
 });
 
 describe(ComputeFullGraph, () => {
+  const expr = mockDeep<Expression>();
+  beforeEach(() => {
+    expr.variables.mockReturnValue(["ctx.n"]);
+  });
+
   const challenge1: ChallengeMetadata = {
     id: 1,
     slug: "",
@@ -684,18 +706,13 @@ describe(ComputeFullGraph, () => {
     expect(result).toEqual([]);
   });
 
-  it("should compute score history with sample data and sample at the right interval", () => {
-    vi.mocked(
-      EvaluateScoringExpression as (
-        expr: Expression,
-        params: Record<string, number>,
-        n: number,
-        all: boolean,
-      ) => [number, number][],
-    ).mockReturnValue([
-      [2, 500],
-      [2, 400],
-    ]);
+  it("should compute score history with a single solve and awards", () => {
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolves([
+        [2, 500],
+        [2, 400],
+      ]),
+    );
 
     const teams = new Map<number, MinimalTeamInfo>([
       [1, { id: 1, division_id: 1, tag_ids: [], flags: [] }],
@@ -727,7 +744,7 @@ describe(ComputeFullGraph, () => {
     const challenges = [
       {
         metadata: challenge1,
-        expr: mockDeep<Expression>(),
+        expr,
       },
     ];
     const solvesByChallenge = new Map<number, RawSolve[]>([
@@ -743,6 +760,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -775,18 +793,13 @@ describe(ComputeFullGraph, () => {
     ]);
   });
 
-  it("should compute score history with sample data and sample at the right interval", () => {
-    vi.mocked(
-      EvaluateScoringExpression as (
-        expr: Expression,
-        params: Record<string, number>,
-        n: number,
-        all: boolean,
-      ) => [number, number][],
-    ).mockReturnValue([
-      [2, 500],
-      [2, 400],
-    ]);
+  it("should compute score history with retroactive score adjustment on tier change", () => {
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolves([
+        [2, 500],
+        [2, 400],
+      ]),
+    );
 
     const teams = new Map<number, MinimalTeamInfo>([
       [1, { id: 1, division_id: 1, tag_ids: [], flags: [] }],
@@ -818,7 +831,7 @@ describe(ComputeFullGraph, () => {
     const challenges = [
       {
         metadata: challenge1,
-        expr: mockDeep<Expression>(),
+        expr,
       },
     ];
     const solvesByChallenge = new Map<number, RawSolve[]>([
@@ -834,6 +847,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -844,6 +858,7 @@ describe(ComputeFullGraph, () => {
             team_id: 2,
             user_id: 2,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -880,17 +895,12 @@ describe(ComputeFullGraph, () => {
   });
 
   it("should ignore hidden teams and results", () => {
-    vi.mocked(
-      EvaluateScoringExpression as (
-        expr: Expression,
-        params: Record<string, number>,
-        n: number,
-        all: boolean,
-      ) => [number, number][],
-    ).mockReturnValue([
-      [2, 500],
-      [2, 400],
-    ]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolves([
+        [2, 500],
+        [2, 400],
+      ]),
+    );
 
     const teams = new Map<number, MinimalTeamInfo>([
       [1, { id: 1, division_id: 1, tag_ids: [], flags: [] }],
@@ -922,11 +932,11 @@ describe(ComputeFullGraph, () => {
     const challenges = [
       {
         metadata: challenge1,
-        expr: mockDeep<Expression>(),
+        expr,
       },
       {
         metadata: { ...challenge1, id: 2 },
-        expr: mockDeep<Expression>(),
+        expr,
       },
     ];
     const solvesByChallenge = new Map<number, RawSolve[]>([
@@ -942,6 +952,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
           {
             challenge_id: 1,
@@ -952,6 +963,7 @@ describe(ComputeFullGraph, () => {
             team_id: 2,
             user_id: 2,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -967,6 +979,7 @@ describe(ComputeFullGraph, () => {
             team_id: 1,
             user_id: 1,
             value: null,
+            weight: 0,
           },
         ],
       ],
@@ -987,6 +1000,814 @@ describe(ComputeFullGraph, () => {
   });
 });
 
+describe("Solve count and weight scoring", () => {
+  const expr = mockDeep<Expression>();
+  const challenge1: ChallengeMetadata = {
+    id: 1,
+    slug: "",
+    title: "",
+    private_metadata: {
+      score: {
+        params: {},
+      },
+    } as Pick<
+      ChallengePrivateMetadataBase,
+      "score"
+    > as ChallengePrivateMetadataBase,
+    tags: {},
+    hidden: false,
+    visible_at: null,
+    created_at: new Date(0),
+    updated_at: new Date(0),
+  };
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("solves with different weights produce different scores when expression uses ctx.w", () => {
+    // score = 1000 - (n * 10) + (w * 5)
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => 1000 - n * 10 + w * 5),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 0,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 10,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 3,
+            created_at: new Date(3000) as unknown as Timestamp & Date,
+            updated_at: new Date(3000) as unknown as Timestamp & Date,
+            team_id: 3,
+            user_id: 3,
+            value: null,
+            weight: 20,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+        [3, { id: 3, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    // n = 3 (all are dynamic solves)
+    // team1: w=0  => 1000 - 30 + 0  = 970
+    // team2: w=10 => 1000 - 30 + 50 = 1020
+    // team3: w=20 => 1000 - 30 + 100 = 1070
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+    const team3 = result.scoreboard.find((s) => s.team_id === 3)!;
+
+    expect(team1.score).toBe(970);
+    expect(team2.score).toBe(1020);
+    expect(team3.score).toBe(1070);
+    // Higher weight = higher score = better rank
+    expect(team3.rank).toBe(1);
+    expect(team2.rank).toBe(2);
+    expect(team1.rank).toBe(3);
+  });
+
+  it("weight=0 for all solves uses only solve count (n)", () => {
+    expr.variables.mockReturnValue(["ctx.n"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, _w) => 500 - n * 50),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 0,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 0,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    // n=2, w=0 for both => 500 - 100 = 400
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+    expect(team1.score).toBe(400);
+    expect(team2.score).toBe(400);
+  });
+
+  it("value overrides bypass weight-based scoring", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => 100 + w * 10 - n),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 5,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: 999,
+            weight: 50,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+
+    // team2 has value override = 999, so weight is irrelevant
+    expect(team2.score).toBe(999);
+    // team1: n=1 (only 1 dynamic solve), w=5 => 100 + 50 - 1 = 149
+    expect(team1.score).toBe(149);
+  });
+
+  it("hidden solves receive weight-based scores but do not contribute to team score", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => 200 + w * 3 - n * 10),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 4,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: ["hidden"], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    // n=1, w=4 => 200 + 12 - 10 = 202
+    expect(team1.score).toBe(202);
+  });
+
+  it("challenge value defaults to w=0 when computing display value", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => 500 - n * 10 + w * 100),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 7,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([[1, { id: 1, flags: [], division_id: 1, tag_ids: [] }]]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    // Challenge display value uses memo(n, 0) => 500 - 10 + 0 = 490
+    const challengeData = result.challenges.get(1)!;
+    expect(challengeData.value).toBe(490);
+
+    // But the solve itself uses weight=7 => 500 - 10 + 700 = 1190
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    expect(team1.score).toBe(1190);
+  });
+
+  it("ComputeFullGraph emits retroactive adjustments with weights", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => 1000 - n * 100 + w * 10),
+    );
+
+    const teams = new Map<number, MinimalTeamInfo>([
+      [1, { id: 1, division_id: 1, tag_ids: [], flags: [] }],
+      [2, { id: 2, division_id: 1, tag_ids: [], flags: [] }],
+    ]);
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 5,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 3,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeFullGraph(
+      teams,
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+      1,
+    );
+
+    // At t=1000: n=1, team1 w=5 => 1000 - 100 + 50 = 950
+    // At t=2000: n=2, team2 w=3 => 1000 - 200 + 30 = 830
+    //   retroactive for team1: n=2, w=5 => 1000 - 200 + 50 = 850 (delta = 850-950 = -100)
+    expect(result).toEqual([
+      { score: 950, team_id: 1, updated_at: new Date(1000) },
+      { score: 850, team_id: 1, updated_at: new Date(2000) },
+      { score: 830, team_id: 2, updated_at: new Date(2000) },
+    ]);
+  });
+});
+
+describe("MemoizeScore black-box cache", () => {
+  const expr = mockDeep<Expression>();
+  const challenge1: ChallengeMetadata = {
+    id: 1,
+    slug: "",
+    title: "",
+    private_metadata: {
+      score: {
+        params: {},
+      },
+    } as Pick<
+      ChallengePrivateMetadataBase,
+      "score"
+    > as ChallengePrivateMetadataBase,
+    tags: {},
+    hidden: false,
+    visible_at: null,
+    created_at: new Date(0),
+    updated_at: new Date(0),
+  };
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("cache returns consistent results for identical (n, w) inputs", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    let callCount = 0;
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      (_expr, _params, ctx: { n: number; w: number }) => {
+        callCount++;
+        return 100 * ctx.n + ctx.w;
+      },
+    );
+
+    // Two solves with the same weight => same (n, w) pair
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 5,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 5,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+
+    // Both should get memo(2, 5) = 200 + 5 = 205
+    expect(team1.score).toBe(205);
+    expect(team2.score).toBe(205);
+  });
+
+  it("cache differentiates between different (n, w) pairs", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => n * 100 + w),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 10,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 20,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 3,
+            created_at: new Date(3000) as unknown as Timestamp & Date,
+            updated_at: new Date(3000) as unknown as Timestamp & Date,
+            team_id: 3,
+            user_id: 3,
+            value: null,
+            weight: 10,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+        [3, { id: 3, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    // n=3 for all; w differs
+    // team1: memo(3, 10) = 310
+    // team2: memo(3, 20) = 320
+    // team3: memo(3, 10) = 310 (should match team1 from cache)
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+    const team3 = result.scoreboard.find((s) => s.team_id === 3)!;
+
+    expect(team1.score).toBe(310);
+    expect(team2.score).toBe(320);
+    expect(team3.score).toBe(310);
+  });
+
+  it("cache works when expression uses only ctx.n (no ctx.w)", () => {
+    expr.variables.mockReturnValue(["ctx.n"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, _w) => 1000 - n * 100),
+    );
+
+    // Different weights should not matter since expr doesn't use ctx.w
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 99,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 1,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    // n=2 for both, w is ignored => 1000 - 200 = 800
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+    expect(team1.score).toBe(800);
+    expect(team2.score).toBe(800);
+  });
+
+  it("cache works when expression uses only ctx.w (no ctx.n)", () => {
+    expr.variables.mockReturnValue(["ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((_n, w) => w * 50),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 3,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 7,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    // w=3 => 150, w=7 => 350
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+    expect(team1.score).toBe(150);
+    expect(team2.score).toBe(350);
+  });
+
+  it("cache works when expression uses neither ctx.n nor ctx.w (static)", () => {
+    expr.variables.mockReturnValue([]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((_n, _w) => 42),
+    );
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 100,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 200,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([
+        [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+        [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      ]),
+      [{ metadata: challenge1, expr }],
+      solvesByChallenge,
+      [],
+    );
+
+    // Static expression: always 42 regardless of n or w
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    const team2 = result.scoreboard.find((s) => s.team_id === 2)!;
+    expect(team1.score).toBe(42);
+    expect(team2.score).toBe(42);
+    expect(result.challenges.get(1)!.value).toBe(42);
+  });
+
+  it("recomputing scoreboard with a fresh MemoizeScore produces same results", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => 500 - n * 25 + w * 3),
+    );
+
+    const teams = new Map<number, MinimalTeamInfo>([
+      [1, { id: 1, flags: [], division_id: 1, tag_ids: [] }],
+      [2, { id: 2, flags: [], division_id: 1, tag_ids: [] }],
+      [3, { id: 3, flags: [], division_id: 1, tag_ids: [] }],
+    ]);
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 0,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 15,
+          },
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 3,
+            created_at: new Date(3000) as unknown as Timestamp & Date,
+            updated_at: new Date(3000) as unknown as Timestamp & Date,
+            team_id: 3,
+            user_id: 3,
+            value: null,
+            weight: 15,
+          },
+        ],
+      ],
+    ]);
+
+    const challenges: ChallengeMetadataWithExpr[] = [
+      { metadata: challenge1, expr },
+    ];
+
+    // First computation (populates cache internally)
+    const result1 = ComputeScoreboard(teams, challenges, solvesByChallenge, []);
+
+    // Second computation (fresh MemoizeScore, but same inputs)
+    const result2 = ComputeScoreboard(teams, challenges, solvesByChallenge, []);
+
+    // Results must be identical
+    expect(
+      result1.scoreboard.map((s) => ({ id: s.team_id, score: s.score })),
+    ).toEqual(
+      result2.scoreboard.map((s) => ({ id: s.team_id, score: s.score })),
+    );
+    expect(result1.challenges.get(1)!.value).toBe(
+      result2.challenges.get(1)!.value,
+    );
+  });
+
+  it("cache handles many distinct weight values correctly across challenges", () => {
+    expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
+    vi.mocked(EvaluateScoringExpression).mockImplementation(
+      MockEvaluateSolvesWithWeight((n, w) => n + w),
+    );
+
+    const challenge2: ChallengeMetadata = {
+      ...challenge1,
+      id: 2,
+    };
+
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            challenge_id: 1,
+            hidden: false,
+            id: 1,
+            created_at: new Date(1000) as unknown as Timestamp & Date,
+            updated_at: new Date(1000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 10,
+          },
+        ],
+      ],
+      [
+        2,
+        [
+          {
+            challenge_id: 2,
+            hidden: false,
+            id: 2,
+            created_at: new Date(2000) as unknown as Timestamp & Date,
+            updated_at: new Date(2000) as unknown as Timestamp & Date,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 20,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(
+      new Map([[1, { id: 1, flags: [], division_id: 1, tag_ids: [] }]]),
+      [
+        { metadata: challenge1, expr },
+        { metadata: challenge2, expr },
+      ],
+      solvesByChallenge,
+      [],
+    );
+
+    const team1 = result.scoreboard.find((s) => s.team_id === 1)!;
+    // challenge1: n=1, w=10 => 11
+    // challenge2: n=1, w=20 => 21
+    // total = 32
+    expect(team1.score).toBe(32);
+
+    // Each challenge has its own MemoizeScore, so display values use w=0
+    expect(result.challenges.get(1)!.value).toBe(1); // n=1, w=0
+    expect(result.challenges.get(2)!.value).toBe(1); // n=1, w=0
+  });
+});
+
 describe(PartitionSolvesByChallenge, () => {
   const baseDate = new Date("2024-01-01T12:00:00Z");
   const earlierDate = new Date("2024-01-01T10:00:00Z");
@@ -1002,6 +1823,7 @@ describe(PartitionSolvesByChallenge, () => {
       created_at: baseDate,
       updated_at: baseDate,
       hidden: false,
+      weight: 0,
     },
     {
       id: 2,
@@ -1012,6 +1834,7 @@ describe(PartitionSolvesByChallenge, () => {
       created_at: laterDate,
       updated_at: laterDate,
       hidden: false,
+      weight: 0,
     },
     {
       id: 3,
@@ -1022,6 +1845,7 @@ describe(PartitionSolvesByChallenge, () => {
       created_at: earlierDate,
       updated_at: earlierDate,
       hidden: true,
+      weight: 0,
     },
     {
       id: 4,
@@ -1032,6 +1856,7 @@ describe(PartitionSolvesByChallenge, () => {
       created_at: baseDate,
       updated_at: baseDate,
       hidden: false,
+      weight: 0,
     },
   ];
 

--- a/core/server-core/src/services/scoreboard/calc.ts
+++ b/core/server-core/src/services/scoreboard/calc.ts
@@ -4,6 +4,7 @@ import {
   ChallengePrivateMetadataBase,
   ScoreboardEntry,
   Solve,
+  Submission,
 } from "@noctf/api/datatypes";
 import { Expression } from "expr-eval";
 import { partition } from "../../util/object.ts";
@@ -42,6 +43,54 @@ export type MinimalScoreboardEntry = Pick<
   ScoreboardEntry,
   "team_id" | "score" | "updated_at" | "last_solve" | "hidden"
 >;
+
+type SubContext = { n: number; w: number };
+
+const CACHE_CAP = 1_000_000;
+
+// This function caches a single score since in most cases the score doesn't really change.
+function MemoizeScore(
+  expr: Expression,
+  params: ChallengePrivateMetadataBase["score"]["params"],
+) {
+  const vars = expr.variables({ withMembers: true });
+  const has = [vars.includes("ctx.n") && "n", vars.includes("ctx.w") && "w"];
+  const count = has.reduce((p, c) => (p += c ? 1 : 0), 0);
+  const k = new Uint16Array(count * 2);
+  function cacheKey(ctx: Record<string, number>) {
+    // short circuit
+    if (!k.length) return 0;
+
+    let c = 0;
+    for (const h of has) {
+      if (!h) continue;
+      const n = ctx[h] || 0;
+      k[c++] = (n >>> 16) & 0xffff;
+      k[c++] = n & 0xffff;
+      if (c === k.length) break;
+    }
+    return String.fromCharCode(...k);
+  }
+
+  const cache = new Map<string | number, number>();
+  const ctx: SubContext = { n: 0, w: 0 };
+  let value: number | undefined = undefined;
+
+  return (n: number, w: number) => {
+    if (ctx.n === n && ctx.w === w && value !== undefined) return value;
+    ctx.n = n;
+    ctx.w = w;
+    const key = cacheKey(ctx);
+    value = cache.get(key);
+    if (value !== undefined) return value;
+
+    value = EvaluateScoringExpression(expr, params, ctx);
+    // This shouldn't happen generally but we don't want the server to crash
+    if (cache.size >= CACHE_CAP) cache.clear();
+    cache.set(key, value);
+    return value;
+  };
+}
 function ComputeScoresForChallenge(
   { metadata, expr }: ChallengeMetadataWithExpr,
   teams: Map<number, MinimalTeamInfo>,
@@ -56,25 +105,15 @@ function ComputeScoresForChallenge(
     ({ team_id, hidden }) =>
       !(teams.get(team_id)?.flags.includes("hidden") || hidden),
   );
-  let base: number;
-  try {
-    base = EvaluateScoringExpression(
-      expr,
-      params,
-      valid.filter(({ value }) => value === null).length,
-    );
-  } catch {
-    return {
-      value: null,
-      solves: [],
-      last_event: new Date(0),
-    };
-  }
+
+  const n = valid.filter(({ value }) => value === null).length;
+
+  const memo = MemoizeScore(expr, params);
 
   let last_event = new Date(0);
   let bonusIdx = 0;
   const rv: Solve[] = valid.map(
-    ({ team_id, user_id, created_at, updated_at, value }) => {
+    ({ team_id, user_id, created_at, updated_at, value, weight }) => {
       last_event = MaxDate(last_event, updated_at);
       const b = value !== null ? undefined : bonus?.[bonusIdx++];
       return {
@@ -83,26 +122,29 @@ function ComputeScoresForChallenge(
         challenge_id: metadata.id,
         bonus: b,
         hidden: false,
-        value: value !== null ? value : base + ((b && Math.round(b)) || 0),
+        value:
+          value !== null
+            ? value
+            : memo(n, weight) + ((b && Math.round(b)) || 0),
         created_at,
       };
     },
   );
   const rh: Solve[] = hidden.map(
-    ({ team_id, user_id, created_at, updated_at }) => {
+    ({ team_id, user_id, created_at, updated_at, weight }) => {
       last_event = MaxDate(last_event, updated_at);
       return {
         team_id,
         user_id,
         challenge_id: metadata.id,
         hidden: true,
-        value: base,
+        value: memo(n, weight),
         created_at,
       };
     },
   );
   return {
-    value: base,
+    value: memo(n, 0), // by default, w is zero
     solves: rv.concat(rh),
     last_event: MaxDate(last_event, metadata.updated_at),
   };
@@ -122,44 +164,33 @@ function ComputeScoreStreamForChallenge(
     ({ team_id, hidden }) =>
       !(teams.get(team_id)?.flags.includes("hidden") || hidden),
   );
-  let base: [number, number][];
-  try {
-    base = EvaluateScoringExpression(
-      expr,
-      params,
-      valid.filter(({ value }) => value === null).length,
-      true,
-    );
-  } catch {
-    return [];
-  }
+
+  const memo = MemoizeScore(expr, params);
   const stream: { team_id: number; delta: number; updated_at: Date }[] = [];
+  const teamScores = new Map<number, { score: number; w: number }>();
   let bonusIdx = 0;
-  let baseIdx = 0;
-  let baseCount = 1;
-  const dyn = new Set<number>();
-  valid.forEach(({ team_id, created_at, value }) => {
+  let n = 0;
+  valid.forEach(({ team_id, created_at, value, weight }) => {
     const b = value !== null ? undefined : bonus?.[bonusIdx++];
-    if (baseCount >= base[baseIdx][0] && baseIdx < base.length - 1) {
-      baseCount = 1;
-      baseIdx += 1;
-      dyn.forEach((team_id) =>
-        stream.push({
-          team_id,
-          delta: base[baseIdx][1] - base[baseIdx - 1][1],
-          updated_at: created_at,
-        }),
-      );
-    } else {
-      baseCount++;
+    if (value === null) {
+      n++;
+      // n changed: emit retroactive score adjustments for all previous solvers
+      for (const [tid, state] of teamScores) {
+        const updated = memo(n, state.w);
+        const delta = updated - state.score;
+        if (delta !== 0) {
+          stream.push({ team_id: tid, delta, updated_at: created_at });
+          state.score = updated;
+        }
+      }
     }
-    dyn.add(team_id);
-    stream.push({
-      team_id,
-      delta:
-        value !== null ? value : base[baseIdx][1] + ((b && Math.round(b)) || 0),
-      updated_at: created_at,
-    });
+    const score =
+      value !== null ? value : memo(n, weight) + ((b && Math.round(b)) || 0);
+    stream.push({ team_id, delta: score, updated_at: created_at });
+    // Only track dynamic solves for future retroactive adjustments
+    if (value === null) {
+      teamScores.set(team_id, { score: memo(n, weight), w: weight });
+    }
   });
   return stream;
 }


### PR DESCRIPTION
## Summary

Adds per-submission `weight` support to the scoring system, allowing individual submissions to influence their score calculation via a `ctx.w` variable in scoring expressions. This is a rework of the previous attempt (`mzllkxnp`) with a fundamentally different approach to dynamic score computation.

## Motivation

Previously, scoring expressions could only reference `ctx.n` (the number of solves). This meant all solves on a challenge were worth the same base score. With weighted challenges, each submission carries a `weight` field that is passed as `ctx.w` into the scoring expression, enabling per-solve score differentiation — e.g., challenges where partial credit or difficulty tiers are needed.

## What changed

### Schema & API
- **Migration**: Adds `weight` (integer, NOT NULL, default 0) column to the `submission` table.
- **Datatypes**: `Submission` type now includes `weight`.
- **Requests**: Bulk submission update API now accepts `weight` as an updatable field.
- **DAO**: `weight` is selected in all submission queries and included in bulk update SQL.

### Scoring engine (`score.ts`)
- **Simplified `EvaluateScoringExpression`**: Removed the overloaded `all: true` variant that returned `[count, score][]` breakpoint arrays. The function now takes a `{ n, w }` context object instead of a bare `n` number.
- **Added context variable validation**: Scoring strategies are validated at registration time to ensure they only reference known context variables (`n`, `w`).

### Scoreboard calculator (`calc.ts`)
- **New `MemoizeScore` helper**: Caches score evaluations keyed on `(n, w)` pairs. Inspects the expression's variables to build a minimal cache key (skipping dimensions the expression doesn't use). Includes a fast-path for repeated identical `(n, w)` lookups.
- **`ComputeScoresForChallenge`**: Replaced the try/catch + single `base` score with a memoized scorer. Each solve now passes its `weight` into `memo(n, weight)` instead of using a flat `base` value.
- **`ComputeScoreStream` (graph mode)**: Completely reworked. The old approach precomputed a `[count, score][]` breakpoint table and walked it with index tracking. The new approach:
  - Processes solves in order, incrementing `n` on each dynamic solve.
  - On each `n` change, emits **retroactive delta adjustments** for all previously-tracked solvers whose score changed (because `n` changed while their `w` stayed the same).
  - Tracks each solver's current score and weight in a `teamScores` map for future retroactive updates.

### Tests (`calc.test.ts`)
- ~800 lines of new tests covering weighted scoring scenarios, including multi-team, multi-challenge, hidden teams, and the score stream path.
- Existing `PartitionSolvesByChallenge` test data updated to include `weight: 0`.

## Key design decisions

1. **Memoization over precomputation**: Instead of precomputing all possible `(n, score)` breakpoints (the old `all: true` path), scores are now evaluated lazily and cached. This naturally extends to the 2D `(n, w)` space without combinatorial blowup.

2. **Retroactive deltas in stream mode**: When `n` changes, previously-scored teams may now have a different score. The stream emits explicit delta corrections rather than trying to predict breakpoints upfront. This is simpler and correct for arbitrary expressions.
