### PR TITLE
[fix] migrate hiding submission to new API

### DIFF
--- a/apps/web/src/routes/admin/submissions/+page.svelte
+++ b/apps/web/src/routes/admin/submissions/+page.svelte
@@ -154,8 +154,7 @@
     try {
       const result = await api.PUT("/admin/submissions", {
         body: {
-          ids: [submissionId],
-          hidden: !currentlyHidden,
+          submissions: [{ id: submissionId, hidden: !currentlyHidden }],
         },
       });
 


### PR DESCRIPTION
Forgot to migrate the edit submissions API on the UI