### PR TITLE
[submissions] add update weighted submission api and http signatures

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -31,6 +31,7 @@
     "awilix": "catalog:",
     "cbor-x": "catalog:",
     "fastify": "catalog:",
+    "http-message-signatures": "^1.0.6",
     "kysely": "catalog:",
     "nanoid": "catalog:"
   },

--- a/apps/server/src/hooks/payload.test.ts
+++ b/apps/server/src/hooks/payload.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "vitest";
+import { Readable } from "node:stream";
+import { createHash } from "node:crypto";
+import { FastifyRequest, FastifyReply } from "fastify";
+import { BadRequestError } from "@noctf/server-core/errors";
+import {
+  PayloadDigestPreParsingHook,
+  PayloadDigestPreValidationHook,
+} from "./payload.ts";
+
+function createMockRequest(
+  headers: Record<string, string | string[]>,
+): FastifyRequest {
+  return {
+    headers,
+    digests: undefined,
+    _parsedDigestHeader: undefined,
+  } as unknown as FastifyRequest;
+}
+
+const mockReply = {} as FastifyReply;
+
+describe(PayloadDigestPreParsingHook, () => {
+  test("should pass through when content-digest header is missing", async () => {
+    const req = createMockRequest({});
+    const data = "hello world";
+    const payload = Readable.from([data]);
+
+    const result = await PayloadDigestPreParsingHook(req, mockReply, payload);
+
+    expect(result).toBe(payload);
+    expect(req.digests).toBeUndefined();
+    expect(req._parsedDigestHeader).toEqual({});
+  });
+
+  test("should throw BadRequestError if content-digest is an array", async () => {
+    const req = createMockRequest({
+      "content-digest": ["sha-256=abc", "sha-512=def"],
+    });
+    const payload = Readable.from(["data"]);
+
+    await expect(
+      PayloadDigestPreParsingHook(req, mockReply, payload),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("should compute sha-256 digest correctly", async () => {
+    const data = "test-payload-data";
+    const hash = createHash("sha256").update(data).digest();
+    const base64Hash = hash.toString("base64");
+
+    const req = createMockRequest({
+      "content-digest": `sha-256=${base64Hash}`,
+    });
+    const payload = Readable.from([data]);
+
+    const resultStream = await PayloadDigestPreParsingHook(
+      req,
+      mockReply,
+      payload,
+    );
+
+    // Consume the returned stream to trigger 'end'
+    const chunks: Buffer[] = [];
+    for await (const chunk of resultStream) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const consumedData = Buffer.concat(chunks).toString();
+
+    expect(consumedData).toBe(data);
+    expect(req._parsedDigestHeader?.["sha-256"]).toEqual(hash);
+    expect(req.digests?.["sha-256"]).toEqual(hash);
+  });
+
+  test("should compute sha-512 digest correctly", async () => {
+    const data = "another-payload-data";
+    const hash = createHash("sha512").update(data).digest();
+    const base64Hash = hash.toString("base64");
+
+    const req = createMockRequest({
+      "content-digest": `sha-512=${base64Hash}`,
+    });
+    const payload = Readable.from([data]);
+
+    const resultStream = await PayloadDigestPreParsingHook(
+      req,
+      mockReply,
+      payload,
+    );
+
+    // Consume the returned stream to trigger 'end'
+    const chunks: Buffer[] = [];
+    for await (const chunk of resultStream) {
+      chunks.push(Buffer.from(chunk));
+    }
+
+    expect(Buffer.concat(chunks).toString()).toBe(data);
+    expect(req._parsedDigestHeader?.["sha-512"]).toEqual(hash);
+    expect(req.digests?.["sha-512"]).toEqual(hash);
+  });
+
+  test("should support multiple digests when no spaces are present in header", async () => {
+    const data = "multi-hash-payload";
+    const hash256 = createHash("sha256").update(data).digest();
+    const hash512 = createHash("sha512").update(data).digest();
+
+    const req = createMockRequest({
+      "content-digest": `sha-256=${hash256.toString("base64")},sha-512=${hash512.toString("base64")}`,
+    });
+    const payload = Readable.from([data]);
+
+    const resultStream = await PayloadDigestPreParsingHook(
+      req,
+      mockReply,
+      payload,
+    );
+
+    // Consume stream
+    for await (const _ of resultStream) {
+      /* noop */
+    }
+
+    expect(req._parsedDigestHeader?.["sha-256"]).toEqual(hash256);
+    expect(req._parsedDigestHeader?.["sha-512"]).toEqual(hash512);
+    expect(req.digests?.["sha-256"]).toEqual(hash256);
+    expect(req.digests?.["sha-512"]).toEqual(hash512);
+  });
+
+  test("should fail with BadRequestError when spaces are present in header (current codebase limitation)", async () => {
+    const req = createMockRequest({
+      "content-digest": "sha-256=abc, sha-512=def",
+    });
+    const payload = Readable.from(["data"]);
+
+    await expect(
+      PayloadDigestPreParsingHook(req, mockReply, payload),
+    ).rejects.toThrow(BadRequestError);
+  });
+
+  test("should throw BadRequestError on invalid algorithms", async () => {
+    const req = createMockRequest({
+      "content-digest": "md5=abc",
+    });
+    const payload = Readable.from(["data"]);
+
+    await expect(
+      PayloadDigestPreParsingHook(req, mockReply, payload),
+    ).rejects.toThrow(BadRequestError);
+  });
+});
+
+describe(PayloadDigestPreValidationHook, () => {
+  test("should throw Error if route is misconfigured (missing _parsedDigestHeader)", async () => {
+    const req = createMockRequest({});
+
+    await expect(PayloadDigestPreValidationHook(req)).rejects.toThrow(
+      "Route is misconfigured",
+    );
+  });
+
+  test("should succeed if computed and parsed digests match", async () => {
+    const digestVal = Buffer.from("matching-digest");
+    const req = {
+      _parsedDigestHeader: { "sha-256": digestVal },
+      digests: { "sha-256": digestVal },
+    } as unknown as FastifyRequest;
+
+    await expect(PayloadDigestPreValidationHook(req)).resolves.not.toThrow();
+  });
+
+  test("should throw BadRequestError if digests do not match", async () => {
+    const parsedDigest = Buffer.from("digest-one");
+    const computedDigest = Buffer.from("digest-two");
+    const req = {
+      _parsedDigestHeader: { "sha-256": parsedDigest },
+      digests: { "sha-256": computedDigest },
+    } as unknown as FastifyRequest;
+
+    await expect(PayloadDigestPreValidationHook(req)).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+
+  test("should throw BadRequestError if digests have different lengths", async () => {
+    const parsedDigest = Buffer.from("short");
+    const computedDigest = Buffer.from("longer-digest-value");
+    const req = {
+      _parsedDigestHeader: { "sha-256": parsedDigest },
+      digests: { "sha-256": computedDigest },
+    } as unknown as FastifyRequest;
+
+    await expect(PayloadDigestPreValidationHook(req)).rejects.toThrow(
+      BadRequestError,
+    );
+  });
+});

--- a/apps/server/src/hooks/payload.ts
+++ b/apps/server/src/hooks/payload.ts
@@ -1,0 +1,93 @@
+import { ApplicationError, BadRequestError } from "@noctf/server-core/errors";
+import { Transform } from "node:stream";
+import { FastifyReply, FastifyRequest, RequestPayload } from "fastify";
+import { createHash, Hash, timingSafeEqual } from "node:crypto";
+
+type AlgoMap = Record<string, { value: Buffer; hash: Hash }>;
+
+declare module "fastify" {
+  interface FastifyRequest {
+    _parsedDigestHeader?: Record<string, Buffer>;
+  }
+}
+
+function parsePair(algos: AlgoMap, pair: string) {
+  const [algo, value] = pair.split("=", 2);
+  if (algo === "sha-256" && !algos["sha-256"]) {
+    algos["sha-256"] = {
+      value: Buffer.from(value, "base64"),
+      hash: createHash("sha256"),
+    };
+    return "sha-256";
+  } else if (algo === "sha-512" && !algos["sha-512"]) {
+    algos["sha-512"] = {
+      value: Buffer.from(value, "base64"),
+      hash: createHash("sha512"),
+    };
+    return "sha-512";
+  }
+  throw new BadRequestError("InvalidHeader");
+}
+
+export const PayloadDigestPreParsingHook = async (
+  request: FastifyRequest,
+  _reply: FastifyReply,
+  payload: RequestPayload,
+) => {
+  // sentinel for validation hook
+  request._parsedDigestHeader = {};
+
+  const header = request.headers["content-digest"];
+  if (!header) return payload;
+  if (Array.isArray(header)) throw new BadRequestError("InvalidHeader");
+
+  const algos: AlgoMap = {};
+  for (const pair of header.split(",")) {
+    try {
+      const algo = parsePair(algos, pair);
+      request._parsedDigestHeader[algo] = algos[algo].value;
+    } catch (e) {
+      if (e instanceof ApplicationError) throw e;
+      throw new BadRequestError("InvalidHeader");
+    }
+  }
+  if (Object.keys(algos).length === 0) return payload;
+  const stream = new Transform({
+    transform(chunk, _encoding, callback) {
+      for (const algo in algos) {
+        algos[algo].hash.update(chunk);
+      }
+      callback(null, chunk);
+    },
+  });
+
+  payload.on("end", () => {
+    request.digests = {};
+    for (const algo in algos) {
+      request.digests[algo] = algos[algo].hash.digest();
+    }
+  });
+  payload.pipe(stream);
+  return stream;
+};
+
+export const PayloadDigestPreValidationHook = async (
+  request: FastifyRequest,
+) => {
+  if (!request._parsedDigestHeader) throw new Error("Route is misconfigured");
+  for (const h in request._parsedDigestHeader) {
+    const parsed = request._parsedDigestHeader[h];
+    const computed = request.digests[h];
+    try {
+      if (
+        computed.length !== parsed.length ||
+        !timingSafeEqual(parsed, computed)
+      ) {
+        throw new BadRequestError("InvalidDigest");
+      }
+    } catch (e) {
+      if (e instanceof ApplicationError) throw e;
+      throw new BadRequestError("InvalidDigest");
+    }
+  }
+};

--- a/apps/server/src/routes/admin_challenge.ts
+++ b/apps/server/src/routes/admin_challenge.ts
@@ -6,13 +6,26 @@ import {
   AdminGetScoringStrategies,
   AdminListChallenges,
   AdminUpdateChallenge,
+  AdminUpdateChallengeWeights,
 } from "@noctf/api/contract/admin_challenge";
+import {
+  ApplicationError,
+  BadRequestError,
+  UnauthorizedError,
+} from "@noctf/server-core/errors";
 import { ActorType } from "@noctf/server-core/types/enums";
 import { route } from "@noctf/server-core/util/route";
+import { createVerifier, httpbis } from "http-message-signatures";
 import type { FastifyInstance } from "fastify";
+import {
+  PayloadDigestPreParsingHook,
+  PayloadDigestPreValidationHook,
+} from "../hooks/payload.ts";
+import { verify } from "crypto";
 
 export async function routes(fastify: FastifyInstance) {
-  const { challengeService, scoreService } = fastify.container.cradle;
+  const { challengeService, scoreService, submissionService } =
+    fastify.container.cradle;
 
   route(
     fastify,
@@ -143,6 +156,60 @@ export async function routes(fastify: FastifyInstance) {
       return {
         data: challengeService.getPrivateMetadataSchema(),
       };
+    },
+  );
+
+  route(
+    fastify,
+    AdminUpdateChallengeWeights,
+    {
+      auth: {
+        // This endpoint uses HMAC-based auth specific to each challenge
+        require: false,
+      },
+    },
+    {
+      preParsing: PayloadDigestPreParsingHook,
+      preValidation: PayloadDigestPreValidationHook,
+      handler: async (request) => {
+        if (!request.digests) {
+          throw new UnauthorizedError("No content-digest provided");
+        }
+        const challenge = await challengeService.get(request.params.id);
+        const verified = await httpbis.verifyMessage(
+          {
+            keyLookup: async () => {
+              const key = challenge.private_metadata.solve.weight_update_key;
+              if (!key) {
+                throw new UnauthorizedError("Invalid signature");
+              }
+              return {
+                verify: createVerifier(key, "hmac-sha256"),
+              };
+            },
+            tolerance: 10,
+            requiredFields: [
+              "@method",
+              "@path",
+              "@authority",
+              "content-digest",
+            ],
+          },
+          {
+            method: request.method,
+            url: new URL(request.url, `${request.protocol}://${request.host}`),
+            headers: request.headers,
+          },
+        );
+        if (!verified) throw new UnauthorizedError("Invalid signature");
+        return {
+          data: await submissionService.upsertWeights(
+            request.params.id,
+            request.body.items,
+            "api:weight_update",
+          ),
+        };
+      },
     },
   );
 }

--- a/apps/server/src/routes/admin_submission.ts
+++ b/apps/server/src/routes/admin_submission.ts
@@ -56,7 +56,7 @@ export async function routes(fastify: FastifyInstance) {
     },
     async (request) => ({
       data: await submissionService.update(
-        request.body,
+        request.body.submissions,
         `user:${request.user?.id}`,
       ),
     }),

--- a/apps/server/src/routes/challenge.ts
+++ b/apps/server/src/routes/challenge.ts
@@ -53,7 +53,7 @@ export async function routes(fastify: FastifyInstance) {
       const scoreObj = await scoreboardService.getChallengesSummary(
         team?.division_id || 1, // TODO: configurable default
       );
-      const solves = new Set<number>();
+      const solves = new Map<number, number>();
 
       // Does not need to rely on scoreboard calcs
       if (team) {
@@ -62,14 +62,16 @@ export async function routes(fastify: FastifyInstance) {
           team.team_id,
         );
         if (entry) {
-          entry.solves.forEach(({ challenge_id }) => solves.add(challenge_id));
+          entry.solves.forEach(({ challenge_id, value }) =>
+            solves.set(challenge_id, value),
+          );
         }
       }
       const values = Object.fromEntries(
         challenges.map((c) => [
           c.id,
           {
-            value: scoreObj[c.id]?.value || 0,
+            value: scoreObj[c.id]?.value || solves.get(c.id) || 0,
             solve_count: scoreObj[c.id]?.solve_count || 0,
             solved_by_me: solves.has(c.id),
           },

--- a/core/api/src/contract/admin_challenge.ts
+++ b/core/api/src/contract/admin_challenge.ts
@@ -1,12 +1,14 @@
 import {
   AdminCreateChallengeRequest,
   AdminUpdateChallengeRequest,
+  AdminUpdateChallengeWeightsRequest,
 } from "../requests.ts";
 import {
   AdminGetChallengeResponse,
   AdminGetScoringStrategiesResponse,
   AdminListChallengesResponse,
   AdminUpdateChallengeResponse,
+  AdminUpdateChallengeWeightsResponse,
   AnyResponse,
   BaseResponse,
 } from "../responses.ts";
@@ -93,6 +95,19 @@ export const AdminGetChallengePrivateMetadataSchema = {
     tags: ["admin"],
     response: {
       200: AnyResponse,
+    },
+  },
+} as const satisfies RouteDef;
+
+export const AdminUpdateChallengeWeights = {
+  method: "PUT",
+  url: "/admin/challenges/:id/weights",
+  schema: {
+    tags: ["admin"],
+    params: IdParams,
+    body: AdminUpdateChallengeWeightsRequest,
+    response: {
+      200: AdminUpdateChallengeWeightsResponse,
     },
   },
 } as const satisfies RouteDef;

--- a/core/api/src/datatypes.ts
+++ b/core/api/src/datatypes.ts
@@ -153,6 +153,9 @@ export const ChallengePrivateMetadataBase = Type.Object(
             input_type: Type.Enum(ChallengeSolveInputType),
           }),
         ),
+        weight_update_key: Type.Optional(
+          Type.String({ maxLength: 128, minLength: 8 }),
+        ),
       },
       { additionalProperties: false },
     ),
@@ -355,7 +358,7 @@ export const Submission = Type.Object({
   source: Type.String({ maxLength: 64 }),
   hidden: Type.Boolean(),
   value: NullableInteger(),
-  weight: Type.Integer(),
+  weight: Type.Integer({ minimum: -1 << 31, maximum: ~(-1 << 31) }),
   status: SubmissionStatus,
   created_at: TypeDate,
   updated_at: TypeDate,

--- a/core/api/src/events.ts
+++ b/core/api/src/events.ts
@@ -14,7 +14,6 @@ export const SubmissionUpdateEvent = Type.Object(
     seq: Type.Integer(),
     is_update: Type.Boolean(),
     status: SubmissionStatus,
-    comments: Type.String(),
   },
   { $id: "events.submission.update" },
 );

--- a/core/api/src/requests.ts
+++ b/core/api/src/requests.ts
@@ -370,6 +370,19 @@ export type AdminUpdateChallengeRequest = Static<
   typeof AdminUpdateChallengeRequest
 >;
 
+export const AdminUpdateChallengeWeightsRequest = Type.Object(
+  {
+    items: Type.Array(Type.Pick(Submission, ["team_id", "weight"]), {
+      minItems: 1,
+      maxItems: 1000,
+    }),
+  },
+  { additionalProperties: false },
+);
+export type AdminUpdateChallengeWeightsRequest = Static<
+  typeof AdminUpdateChallengeWeightsRequest
+>;
+
 export const SolveChallengeRequest = Type.Object(
   {
     data: Type.String({ maxLength: 512 }),

--- a/core/api/src/responses.ts
+++ b/core/api/src/responses.ts
@@ -266,6 +266,13 @@ export type AdminUpdateChallengeResponse = Static<
   typeof AdminUpdateChallengeResponse
 >;
 
+export const AdminUpdateChallengeWeightsResponse = Type.Object({
+  data: Type.Array(Type.Pick(Submission, ["id", "team_id"])),
+});
+export type AdminUpdateChallengeWeightsResponse = Static<
+  typeof AdminUpdateChallengeWeightsResponse
+>;
+
 export const AnyResponse = Type.Object(
   {
     data: Type.Any(),
@@ -348,7 +355,7 @@ export type AdminQuerySubmissionsResponse = Static<
 >;
 
 export const AdminUpdateSubmissionsResponse = Type.Object({
-  data: Type.Array(Type.Number()),
+  data: Type.Array(Type.Pick(Submission, ["id"])),
 });
 export type AdminUpdateSubmissionsResponse = Static<
   typeof AdminUpdateSubmissionsResponse

--- a/core/server-core/src/dao/submission.ts
+++ b/core/server-core/src/dao/submission.ts
@@ -1,7 +1,7 @@
 import type { DB } from "@noctf/schema";
 import { sql, type Insertable } from "kysely";
 import { DBType } from "../clients/database.ts";
-import { ChallengeStat, LimitOffset, Submission } from "@noctf/api/datatypes";
+import { LimitOffset, Submission } from "@noctf/api/datatypes";
 import { SubmissionStatus } from "@noctf/api/enums";
 import { PostgresErrorCode, TryPGConstraintError } from "../util/pgerror.ts";
 import { ConflictError } from "../errors.ts";
@@ -19,6 +19,18 @@ export type RawSolve = Pick<
   | "value"
   | "weight"
 >;
+
+export type ReturnedSubmissionUpdate = Pick<
+  Submission,
+  | "id"
+  | "hidden"
+  | "status"
+  | "user_id"
+  | "team_id"
+  | "challenge_id"
+  | "created_at"
+  | "updated_at"
+> & { seq: number };
 
 const GetSeq = (eb: ExpressionBuilder<DB, "submission">) =>
   eb
@@ -80,19 +92,7 @@ export class SubmissionDAO {
       status?: SubmissionStatus;
       value?: number | null;
     }[],
-  ): Promise<
-    (Pick<
-      Submission,
-      | "id"
-      | "user_id"
-      | "team_id"
-      | "challenge_id"
-      | "hidden"
-      | "created_at"
-      | "updated_at"
-      | "status"
-    > & { seq: number })[]
-  > {
+  ): Promise<ReturnedSubmissionUpdate[]> {
     const vs = sql.join(
       values.map(
         (v) => sql`(
@@ -344,5 +344,56 @@ export class SubmissionDAO {
       correct_count: Number(x.correct_count),
       incorrect_count: Number(x.incorrect_count),
     }));
+  }
+
+  async upsertWeights(
+    values: {
+      challenge_id: number;
+      team_id: number;
+      weight: number;
+    }[],
+  ): Promise<ReturnedSubmissionUpdate[]> {
+    return (
+      await this.db
+        .insertInto("submission")
+        .values(
+          values.map((v) => ({
+            status: "correct",
+            challenge_id: v.challenge_id,
+            team_id: v.team_id,
+            weight: v.weight,
+            source: "weight",
+          })),
+        )
+        .onConflict((oc) =>
+          oc
+            .columns(["challenge_id", "team_id"])
+            .where(sql`status`, "in", sql`('queued', 'correct')`)
+            .doUpdateSet((eb) => ({
+              status: "correct",
+              weight: eb.ref("excluded.weight"),
+              user_id: null,
+            }))
+            .where((eb) =>
+              eb.or([
+                eb("submission.status", "!=", "correct"),
+                eb("submission.weight", "!=", eb.ref("excluded.weight")),
+                eb("submission.user_id", "!=", null),
+              ]),
+            ),
+        )
+        .returning((eb) => [
+          "submission.id as id",
+          "submission.hidden as hidden",
+          "submission.status as status",
+          "user_id",
+          "team_id",
+          "challenge_id",
+          "created_at",
+          "updated_at",
+          GetSeq(eb).as("seq"),
+        ])
+        .execute()
+    ).map((x) => ({ ...x, seq: Number(x.seq) }));
   }
 }

--- a/core/server-core/src/services/challenge/index.ts
+++ b/core/server-core/src/services/challenge/index.ts
@@ -271,7 +271,6 @@ export class ChallengeService {
         seq: solved ? seq + 1 : 0,
         hidden: false,
         is_update: false,
-        comments: state.comment || "",
       });
       return { status: state.status, created_at };
       // TODO: queueing, currently it is just marked as queued. probably emit

--- a/core/server-core/src/services/notification.ts
+++ b/core/server-core/src/services/notification.ts
@@ -262,7 +262,6 @@ export class NotificationService {
               user_name: user?.name || "",
               id: event.id,
               seq: event.seq,
-              comments: event.comments,
               status: event.status,
               is_update: event.is_update,
               created_at: event.created_at,

--- a/core/server-core/src/services/score.ts
+++ b/core/server-core/src/services/score.ts
@@ -25,6 +25,12 @@ const STRATEGIES: Record<string, ScoringStrategy> = {
       "Based on the CCC CTF dynamic scoring formula. initial is" +
       " the maximum score, k is the scaling factor and j is the exponent.",
   },
+  bounded_weight: {
+    expr: "max(lower, min(upper, ctx.w))",
+    description:
+      "A simple formula to clamp an externally provided weight between" +
+      " a lower and upper bound.",
+  },
 };
 
 const parser = new Parser({

--- a/core/server-core/src/services/submission.ts
+++ b/core/server-core/src/services/submission.ts
@@ -1,12 +1,17 @@
 import { AdminUpdateSubmissionsRequest } from "@noctf/api/requests";
 import { ServiceCradle } from "../index.ts";
-import { SubmissionDAO } from "../dao/submission.ts";
+import {
+  RawSolve,
+  ReturnedSubmissionUpdate,
+  SubmissionDAO,
+} from "../dao/submission.ts";
 import { AuditParams } from "../types/audit_log.ts";
 import { SubmissionUpdateEvent } from "@noctf/api/events";
 import { SubmissionStatus } from "@noctf/api/enums";
 import { SubmissionLogDAO } from "../dao/submission_log.ts";
 import { FilterUndefined } from "../util/filter.ts";
 import { BadRequestError } from "../errors.ts";
+import { Submission } from "@noctf/schema";
 
 type Props = Pick<ServiceCradle, "databaseClient" | "eventBusService">;
 export class SubmissionService {
@@ -48,8 +53,10 @@ export class SubmissionService {
     return this.dao.getCount(params);
   }
 
-  async update(r: AdminUpdateSubmissionsRequest, actor: string) {
-    const { submissions } = r;
+  async update(
+    submissions: AdminUpdateSubmissionsRequest["submissions"],
+    actor: string,
+  ) {
     const map = submissions.reduce((prev, cur) => {
       prev.set(cur.id, cur);
       return prev;
@@ -91,10 +98,55 @@ export class SubmissionService {
       }
       return updates;
     });
+    updates.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+    await this.sendUpdateEvents(updates);
+    return updates;
+  }
 
+  async upsertWeights(
+    challenge_id: number,
+    items: Pick<RawSolve, "team_id" | "weight">[],
+    actor: string,
+  ) {
+    const map = new Map<number, (typeof items)[number]>();
+    const values = items.map((v) => {
+      map.set(v.team_id, v);
+      return {
+        team_id: v.team_id,
+        weight: v.weight,
+        challenge_id,
+      };
+    });
+    if (map.size !== items.length) {
+      throw new BadRequestError("Duplicate items detected in update");
+    }
+
+    const updates = await this.databaseClient.transaction(async (tx) => {
+      const submissionDAO = new SubmissionDAO(tx);
+      const updates = await submissionDAO.upsertWeights(values);
+      if (updates.length > 0) {
+        const logDAO = new SubmissionLogDAO(tx);
+        await logDAO.create(
+          updates.map((u) => {
+            return {
+              comments: "",
+              submission_id: u.id,
+              actor,
+              changes: { weight: map.get(u.id)?.weight },
+            };
+          }),
+        );
+      }
+      return updates;
+    });
+    updates.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
+    await this.sendUpdateEvents(updates);
+    return updates;
+  }
+
+  private async sendUpdateEvents(updates: ReturnedSubmissionUpdate[]) {
     // The DB returns the same seq if we update multiple records for the
     // same challenge to correct at the same time.
-    updates.sort((a, b) => a.created_at.getTime() - b.created_at.getTime());
     const seqMap = new Map<number, number>();
     for (const {
       id,
@@ -120,9 +172,7 @@ export class SubmissionService {
         hidden,
         seq: status === "correct" ? seq + vSeq : 0,
         is_update: true,
-        comments: map.get(id)?.comments || "",
       });
     }
-    return updates.map(({ id }) => id);
   }
 }

--- a/core/server-core/src/types/fastify.ts
+++ b/core/server-core/src/types/fastify.ts
@@ -36,6 +36,8 @@ declare module "fastify" {
   }
 
   interface FastifyRequest {
+    // Won't exist on every request
+    digests?: Record<string, Buffer>;
     user?: {
       app?: number;
       id: number;

--- a/core/server-core/src/util/route.ts
+++ b/core/server-core/src/util/route.ts
@@ -26,6 +26,8 @@ export type RouteSchema<T extends RouteDef> = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Options<T> = T extends (arg1: infer U, ...args: any[]) => any ? U : never;
 
+type AtLeast<T, K extends keyof T> = Partial<Omit<T, K>> & Pick<T, K>;
+
 export function route<
   Def extends RouteDef,
   SchemaDef extends RouteSchema<Def>,
@@ -34,13 +36,24 @@ export function route<
   fastify: Instance,
   def: Def,
   config: RequestConfig<SchemaDef>,
-  handler: Options<typeof fastify.route<SchemaDef>>["handler"],
+  handler:
+    | Options<typeof fastify.route<SchemaDef>>["handler"]
+    | AtLeast<Options<typeof fastify.route<SchemaDef>>, "handler">,
 ) {
+  if (typeof handler === "function") {
+    return fastify.route<SchemaDef>({
+      method: def.method,
+      url: def.url,
+      schema: { ...def.schema, security: [{ bearer: [] }] },
+      config,
+      handler,
+    });
+  }
   return fastify.route<SchemaDef>({
     method: def.method,
     url: def.url,
     schema: { ...def.schema, security: [{ bearer: [] }] },
     config,
-    handler,
+    ...handler,
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       fastify:
         specifier: 'catalog:'
         version: 5.2.0
+      http-message-signatures:
+        specifier: ^1.0.6
+        version: 1.0.6
       kysely:
         specifier: 'catalog:'
         version: 0.27.5
@@ -2830,6 +2833,9 @@ packages:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-message-signatures@1.0.6:
+    resolution: {integrity: sha512-mGaW/gs0WyP1X4wcc0iHguoDuv/LGyGLbvn8NWgbSdR+opFXKncrNiwQO8bN5rZ5j0z9HrwrRj33CzIK5dhGXA==}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
@@ -4174,6 +4180,10 @@ packages:
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
+  structured-headers@2.0.3:
+    resolution: {integrity: sha512-4g5yxhlDMClRwCcfKfLeS7Z8yAVdOWGDADwm80Poh1iReU2KVKLGBlqwpHWJ2qovq0+ZIf1atAEO1eua2o9Rgg==}
+    engines: {node: '>=18', npm: '>=6'}
+
   style-mod@4.1.2:
     resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
 
@@ -4576,6 +4586,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -5045,7 +5056,7 @@ snapshots:
   '@eslint/config-array@0.19.1':
     dependencies:
       '@eslint/object-schema': 2.1.5
-      debug: 4.4.0
+      debug: 4.4.1(supports-color@9.4.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5057,7 +5068,7 @@ snapshots:
   '@eslint/eslintrc@3.2.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0
+      debug: 4.4.1(supports-color@9.4.0)
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5604,7 +5615,7 @@ snapshots:
   '@sveltejs/vite-plugin-svelte-inspector@3.0.1(@sveltejs/vite-plugin-svelte@4.0.4(svelte@5.17.3)(vite@5.4.19(@types/node@22.10.2)(sass@1.89.2)(terser@5.43.1)))(svelte@5.17.3)(vite@5.4.19(@types/node@22.10.2)(sass@1.89.2)(terser@5.43.1))':
     dependencies:
       '@sveltejs/vite-plugin-svelte': 4.0.4(svelte@5.17.3)(vite@5.4.19(@types/node@22.10.2)(sass@1.89.2)(terser@5.43.1))
-      debug: 4.4.0
+      debug: 4.4.1(supports-color@9.4.0)
       svelte: 5.17.3
       vite: 5.4.19(@types/node@22.10.2)(sass@1.89.2)(terser@5.43.1)
     transitivePeerDependencies:
@@ -6879,6 +6890,10 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
+
+  http-message-signatures@1.0.6:
+    dependencies:
+      structured-headers: 2.0.3
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -8417,6 +8432,8 @@ snapshots:
   strip-json-comments@3.1.1: {}
 
   strnum@1.1.2: {}
+
+  structured-headers@2.0.3: {}
 
   style-mod@4.1.2: {}
 


### PR DESCRIPTION
### Description

This PR adds a highly scoped `PUT /admin/challenges/:id/weights` endpoint designed for external scoring mechanisms like **King of the Hill (KotH)**, **Attack/Defense (A/D)**, or custom challenge orchestrators to push team-specific weights directly to the platform.

### Why?

* **External Scoring Automation:** Dynamic gamemodes like KotH and A/D require automated external daemons to calculate and update scores continuously.
* **Least Privilege Security:** These external scripts do not need full administrative service accounts. A single challenge-specific signature token (`weight_update_key`) provides enough access while safely isolating the blast radius if the challenge infrastructure is compromised.
### Core Changes

* **Dynamic Weighting Routes (`apps/server/src/routes/admin_challenge.ts`):** Exposes the `PUT` endpoint using `hmac-sha256` payload verification against `weight_update_key`.
* **Payload Digest Validation (`apps/server/src/hooks/payload.ts`):** Adds Fastify `preParsing` and `preValidation` hooks to compute stream hashes inline and enforce payload integrity using `crypto.timingSafeEqual` to prevent timing attacks.
* **Challenge UI Fix (`apps/server/src/routes/challenge.ts`):** Returns the team actual score for the challenge in the list endpoint if it's solved by them.
* **Refactoring:** Drops unused `comments` strings from `SubmissionUpdateEvent` to optimize WebSocket payload sizes and adapts the `route()` helper to accept standard Fastify hook layouts.

### Usage Example

External scoring scripts must send a `PUT` request with a `content-digest` header, signed using the challenge's specific `weight_update_key` via HTTP Message Signatures (specifying `@method`, `@path`, `@authority`, and `content-digest`). Weights must be provided as **integers (int32)**.

#### Request Payload

```json
PUT /admin/challenges/42/weights
Content-Digest: sha-256=X4aCw...
Signature-Input: sig1=("@method" "@path" "@authority" "content-digest");keyid="challenge-key";alg="hmac-sha256"
Signature: sig1=:p5GkX...

{
  "items": [
    { "team_id": 12, "weight": 100 },
    { "team_id": 15, "weight": 50 }
  ]
}

```

### Verification Plan

* **Automated Tests:** Comprehensive coverage added to `payload.test.ts` checking stream hashing, algorithm variants, and malformed headers.
* **Manual Verification:** Verified normal solves process without disruption, and that signed weight payloads apply accurately while rejected keys throw `UnauthorizedError`.