### PR TITLE
[calc] dont use toJSFunction

### DIFF
--- a/core/server-core/src/services/scoreboard/calc.test.ts
+++ b/core/server-core/src/services/scoreboard/calc.test.ts
@@ -20,7 +20,7 @@ import { MinimalTeamInfo } from "../../dao/team.ts";
 import { RawSolve } from "../../dao/submission.ts";
 
 function MockEvaluateSolves(series: [number, number][]) {
-  return ({ n }: { n: number }) => {
+  return ({ ctx: { n } }: { ctx: { n: number } }) => {
     let remain = n;
     for (const s of series) {
       if (remain - s[0] >= 0) {
@@ -34,7 +34,7 @@ function MockEvaluateSolves(series: [number, number][]) {
 }
 
 function MockEvaluateSolvesWithWeight(fn: (n: number, w: number) => number) {
-  return (ctx: { n: number; w: number }) => fn(ctx.n, ctx.w);
+  return ({ ctx }: { ctx: { n: number; w: number } }) => fn(ctx.n, ctx.w);
 }
 
 describe(GetChangedTeamScores, () => {
@@ -203,11 +203,11 @@ describe(GetChangedTeamScores, () => {
 
 describe(ComputeScoreboard, () => {
   const expr = mockDeep<Expression>();
-  const mockToJSFunction = vi.fn();
+  const mockEvaluate = vi.fn();
   beforeEach(() => {
     expr.variables.mockReturnValue(["ctx.n"]);
     expr.simplify.mockReturnValue({
-      toJSFunction: mockToJSFunction,
+      evaluate: mockEvaluate,
     } as any);
   });
   const challenge1: ChallengeMetadata = {
@@ -243,7 +243,7 @@ describe(ComputeScoreboard, () => {
   });
 
   it("Value overrides for solves do not count towards dynamic scoring", () => {
-    mockToJSFunction.mockReturnValue(() => 1);
+    mockEvaluate.mockReturnValue(1);
     const solvesByChallenge = new Map<number, RawSolve[]>([
       [
         1,
@@ -369,11 +369,11 @@ describe(ComputeScoreboard, () => {
         ],
       ]),
     });
-    mockToJSFunction.mockReturnValue(() => 1);
+    mockEvaluate.mockReturnValue(1);
   });
 
   it("Calculates challenge scores, uses the last valid solve date as the date", () => {
-    mockToJSFunction.mockReturnValue(() => 1);
+    mockEvaluate.mockReturnValue(1);
     const solvesByChallenge = new Map<number, RawSolve[]>([
       [
         1,
@@ -532,7 +532,7 @@ describe(ComputeScoreboard, () => {
   });
 
   it("Calculates challenge scores and adds awards to date", () => {
-    mockToJSFunction.mockReturnValue(() => 1);
+    mockEvaluate.mockReturnValue(1);
     const solvesByChallenge = new Map<number, RawSolve[]>([
       [
         1,
@@ -656,11 +656,11 @@ describe(ComputeScoreboard, () => {
 
 describe(ComputeFullGraph, () => {
   const expr = mockDeep<Expression>();
-  const mockToJSFunction = vi.fn();
+  const mockEvaluate = vi.fn();
   beforeEach(() => {
     expr.variables.mockReturnValue(["ctx.n"]);
     expr.simplify.mockReturnValue({
-      toJSFunction: mockToJSFunction,
+      evaluate: mockEvaluate,
     } as any);
   });
 
@@ -704,7 +704,7 @@ describe(ComputeFullGraph, () => {
   });
 
   it("should compute score history with a single solve and awards", () => {
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolves([
         [2, 500],
         [2, 400],
@@ -791,7 +791,7 @@ describe(ComputeFullGraph, () => {
   });
 
   it("should compute score history with retroactive score adjustment on tier change", () => {
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolves([
         [2, 500],
         [2, 400],
@@ -892,7 +892,7 @@ describe(ComputeFullGraph, () => {
   });
 
   it("should ignore hidden teams and results", () => {
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolves([
         [2, 500],
         [2, 400],
@@ -999,10 +999,10 @@ describe(ComputeFullGraph, () => {
 
 describe("Solve count and weight scoring", () => {
   const expr = mockDeep<Expression>();
-  const mockToJSFunction = vi.fn();
+  const mockEvaluate = vi.fn();
   beforeEach(() => {
     expr.simplify.mockReturnValue({
-      toJSFunction: mockToJSFunction,
+      evaluate: mockEvaluate,
     } as any);
   });
   const challenge1: ChallengeMetadata = {
@@ -1031,7 +1031,7 @@ describe("Solve count and weight scoring", () => {
   it("solves with different weights produce different scores when expression uses ctx.w", () => {
     // score = 1000 - (n * 10) + (w * 5)
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => 1000 - n * 10 + w * 5),
     );
 
@@ -1106,7 +1106,7 @@ describe("Solve count and weight scoring", () => {
 
   it("weight=0 for all solves uses only solve count (n)", () => {
     expr.variables.mockReturnValue(["ctx.n"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, _w) => 500 - n * 50),
     );
 
@@ -1159,7 +1159,7 @@ describe("Solve count and weight scoring", () => {
 
   it("value overrides bypass weight-based scoring", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => 100 + w * 10 - n),
     );
 
@@ -1214,7 +1214,7 @@ describe("Solve count and weight scoring", () => {
 
   it("hidden solves receive weight-based scores but do not contribute to team score", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => 200 + w * 3 - n * 10),
     );
 
@@ -1254,7 +1254,7 @@ describe("Solve count and weight scoring", () => {
 
   it("challenge value defaults to w=0 when computing display value", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => 500 - n * 10 + w * 100),
     );
 
@@ -1295,7 +1295,7 @@ describe("Solve count and weight scoring", () => {
 
   it("ComputeFullGraph emits retroactive adjustments with weights", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => 1000 - n * 100 + w * 10),
     );
 
@@ -1355,10 +1355,10 @@ describe("Solve count and weight scoring", () => {
 
 describe("MemoizeScore black-box cache", () => {
   const expr = mockDeep<Expression>();
-  const mockToJSFunction = vi.fn();
+  const mockEvaluate = vi.fn();
   beforeEach(() => {
     expr.simplify.mockReturnValue({
-      toJSFunction: mockToJSFunction,
+      evaluate: mockEvaluate,
     } as any);
   });
   const challenge1: ChallengeMetadata = {
@@ -1387,10 +1387,12 @@ describe("MemoizeScore black-box cache", () => {
   it("cache returns consistent results for identical (n, w) inputs", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
     let callCount = 0;
-    mockToJSFunction.mockReturnValue((ctx: { n: number; w: number }) => {
-      callCount++;
-      return 100 * ctx.n + ctx.w;
-    });
+    mockEvaluate.mockImplementation(
+      ({ ctx }: { ctx: { n: number; w: number } }) => {
+        callCount++;
+        return 100 * ctx.n + ctx.w;
+      },
+    );
 
     // Two solves with the same weight => same (n, w) pair
     const solvesByChallenge = new Map<number, RawSolve[]>([
@@ -1443,7 +1445,7 @@ describe("MemoizeScore black-box cache", () => {
 
   it("cache differentiates between different (n, w) pairs", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => n * 100 + w),
     );
 
@@ -1514,7 +1516,7 @@ describe("MemoizeScore black-box cache", () => {
 
   it("cache works when expression uses only ctx.n (no ctx.w)", () => {
     expr.variables.mockReturnValue(["ctx.n"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, _w) => 1000 - n * 100),
     );
 
@@ -1568,7 +1570,7 @@ describe("MemoizeScore black-box cache", () => {
 
   it("cache works when expression uses only ctx.w (no ctx.n)", () => {
     expr.variables.mockReturnValue(["ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((_n, w) => w * 50),
     );
 
@@ -1621,7 +1623,7 @@ describe("MemoizeScore black-box cache", () => {
 
   it("cache works when expression uses neither ctx.n nor ctx.w (static)", () => {
     expr.variables.mockReturnValue([]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((_n, _w) => 42),
     );
 
@@ -1675,7 +1677,7 @@ describe("MemoizeScore black-box cache", () => {
 
   it("recomputing scoreboard with a fresh MemoizeScore produces same results", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => 500 - n * 25 + w * 3),
     );
 
@@ -1749,7 +1751,7 @@ describe("MemoizeScore black-box cache", () => {
 
   it("cache handles many distinct weight values correctly across challenges", () => {
     expr.variables.mockReturnValue(["ctx.n", "ctx.w"]);
-    mockToJSFunction.mockReturnValue(
+    mockEvaluate.mockImplementation(
       MockEvaluateSolvesWithWeight((n, w) => n + w),
     );
 

--- a/core/server-core/src/services/scoreboard/calc.ts
+++ b/core/server-core/src/services/scoreboard/calc.ts
@@ -78,7 +78,7 @@ function MemoizeScore(
   const ctx: SubContext = { n: 0, w: 0 };
   let value: number | undefined = undefined;
 
-  const exprFn = expr.simplify(params).toJSFunction("ctx");
+  const simplified = expr.simplify(params);
   return (n: number, w: number) => {
     if (ctx.n === n && ctx.w === w && value !== undefined) return value;
     ctx.n = n;
@@ -87,7 +87,7 @@ function MemoizeScore(
     value = cache.get(key);
     if (value !== undefined) return value;
 
-    value = Math.round(exprFn(ctx));
+    value = Math.round(simplified.evaluate({ ctx }));
     // This shouldn't happen generally but we don't want the server to crash
     if (cache.size >= CACHE_CAP) cache.clear();
     cache.set(key, value);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ catalogs:
       specifier: ^9.17.0
       version: 9.17.0
     expr-eval:
-      specifier: npm:expr-eval-fork@^2.0.2
-      version: 2.0.2
+      specifier: npm:expr-eval-fork@^3.0.3
+      version: 3.0.3
     fastify:
       specifier: ^5.2.0
       version: 5.2.0
@@ -255,7 +255,7 @@ importers:
         version: 4.1.0
       expr-eval:
         specifier: 'catalog:'
-        version: expr-eval-fork@2.0.2
+        version: expr-eval-fork@3.0.3
       i18n-iso-countries:
         specifier: ^7.14.0
         version: 7.14.0
@@ -483,7 +483,7 @@ importers:
         version: 1.6.0
       expr-eval:
         specifier: 'catalog:'
-        version: expr-eval-fork@2.0.2
+        version: expr-eval-fork@3.0.3
       fastify:
         specifier: 'catalog:'
         version: 5.2.0
@@ -2574,8 +2574,9 @@ packages:
     resolution: {integrity: sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==}
     engines: {node: '>=12.0.0'}
 
-  expr-eval-fork@2.0.2:
-    resolution: {integrity: sha512-NaAnObPVwHEYrODd7Jzp3zzT9pgTAlUUL4MZiZu9XAYPDpx89cPsfyEImFb2XY0vQNbrqg2CG7CLiI+Rs3seaQ==}
+  expr-eval-fork@3.0.3:
+    resolution: {integrity: sha512-BhC+hbc5lIVjygr840n5DEkW3MQq7H9o+mc1/N7Z5uIiCFVyESLL5DIE7LNq4CYUNxy+XjA+3jRrL/h0Kt2xcg==}
+    engines: {node: '>=16.9.0'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -6589,7 +6590,7 @@ snapshots:
 
   expect-type@1.1.0: {}
 
-  expr-eval-fork@2.0.2: {}
+  expr-eval-fork@3.0.3: {}
 
   extend@3.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -36,4 +36,4 @@ catalog:
   "vitest-mock-extended": ^2.0.2
   "openapi-typescript": "^7.5.2"
   "openapi-fetch": "^0.13.4"
-  "expr-eval": "npm:expr-eval-fork@^2.0.2"
+  "expr-eval": "npm:expr-eval-fork@^3.0.3"


### PR DESCRIPTION
upgrade expr-eval to fix [CVE-2025-12735](https://nvd.nist.gov/vuln/detail/CVE-2025-12735)

shouldn't be too much of a concern for us as we heavily sanitize inputs