### PR TITLE
add batch publish to eventbus

### DIFF
--- a/apps/server/src/routes/scoreboard.ts
+++ b/apps/server/src/routes/scoreboard.ts
@@ -32,10 +32,7 @@ export async function routes(fastify: FastifyInstance) {
       },
     },
     async (request) => {
-      const admin = await gateStartTime(
-        adminPolicy,
-        request.user?.id,
-      );
+      const admin = await gateStartTime(adminPolicy, request.user?.id);
       const id = request.params.id;
       if (!admin && id !== (await request.user?.membership)?.division_id) {
         const division = await divisionService.get(id);

--- a/core/server-core/src/services/event_bus.ts
+++ b/core/server-core/src/services/event_bus.ts
@@ -13,6 +13,7 @@ import { SimpleMutex } from "nats/lib/nats-base-client/util.js";
 import { decode, encode } from "cbor-x";
 import { Compress, Decompress } from "../util/message_compression.ts";
 import { Static, TSchema } from "@sinclair/typebox";
+import { RunInParallelWithLimit } from "../util/semaphore.ts";
 
 type Props = Pick<
   ServiceCradle,
@@ -159,10 +160,23 @@ export class EventBusService {
     if (!this.natsClient) {
       await this.init();
     }
-    await this.natsClient.publish(
+    this.natsClient.publish(
       typeof subject === "string" ? subject : subject.$id!,
       await Compress(encode(data)),
     );
+  }
+
+  async publishBatch<T extends TSchema | string>(
+    subject: T,
+    data: (T extends TSchema ? Static<T> : unknown)[],
+  ) {
+    if (!this.natsClient) {
+      await this.init();
+    }
+    const sub = typeof subject === "string" ? subject : subject.$id!;
+    await RunInParallelWithLimit(data, 8, async (item) => {
+      this.natsClient.publish(sub, await Compress(encode(item)));
+    });
   }
 
   private async listen<T>(

--- a/core/server-core/src/services/submission.ts
+++ b/core/server-core/src/services/submission.ts
@@ -163,6 +163,8 @@ export class SubmissionService {
     // The DB returns the same seq if we update multiple records for the
     // same challenge to correct at the same time.
     const seqMap = new Map<number, number>();
+    const messages = new Array(updates.length);
+    let i = 0;
     for (const {
       id,
       status,
@@ -176,7 +178,7 @@ export class SubmissionService {
     } of updates) {
       const vSeq = (seqMap.get(challenge_id) || 0) + 1;
       seqMap.set(challenge_id, vSeq);
-      await this.eventBusService.publish(SubmissionUpdateEvent, {
+      messages[i++] = {
         id,
         user_id: user_id || undefined,
         team_id,
@@ -187,7 +189,8 @@ export class SubmissionService {
         hidden,
         seq: status === "correct" ? seq + vSeq : 0,
         is_update: true,
-      });
+      };
     }
+    await this.eventBusService.publishBatch(SubmissionUpdateEvent, messages);
   }
 }


### PR DESCRIPTION
for large payloads, we don't need to publish and await in an async loop. add a publishbatch function which is more streamlined

nats.publish is a sync function https://nats-io.github.io/nats.js/core/interfaces/NatsConnection.html#publish-1 so we don't need to await