### PR TITLE
[calc] minor optimisations

### DIFF
--- a/core/server-core/src/services/scoreboard/calc.test.ts
+++ b/core/server-core/src/services/scoreboard/calc.test.ts
@@ -242,6 +242,55 @@ describe(ComputeScoreboard, () => {
     });
   });
 
+  it("Correctly assigns tied rank when multiple teams have the same score and same last_solve timestamp", () => {
+    mockEvaluate.mockReturnValue(100);
+    const teams = new Map<number, MinimalTeamInfo>([
+      [1, { id: 1, name: "team1", flags: [], tag_ids: [] }],
+      [2, { id: 2, name: "team2", flags: [], tag_ids: [] }],
+    ]);
+    const challenges: ChallengeMetadataWithExpr[] = [
+      { metadata: challenge1, expr },
+    ];
+    // Both teams solved at the exact same timestamp, but distinct Date object instances
+    const solvesByChallenge = new Map<number, RawSolve[]>([
+      [
+        1,
+        [
+          {
+            id: 1,
+            challenge_id: 1,
+            team_id: 1,
+            user_id: 1,
+            value: null,
+            weight: 0,
+            hidden: false,
+            created_at: new Date(5000) as unknown as Timestamp & Date,
+            updated_at: new Date(5000) as unknown as Timestamp & Date,
+          },
+          {
+            id: 2,
+            challenge_id: 1,
+            team_id: 2,
+            user_id: 2,
+            value: null,
+            weight: 0,
+            hidden: false,
+            created_at: new Date(5000) as unknown as Timestamp & Date,
+            updated_at: new Date(5000) as unknown as Timestamp & Date,
+          },
+        ],
+      ],
+    ]);
+
+    const result = ComputeScoreboard(teams, challenges, solvesByChallenge, []);
+    expect(result.scoreboard).toHaveLength(2);
+    expect(result.scoreboard[0].score).toBe(100);
+    expect(result.scoreboard[1].score).toBe(100);
+    // Both teams must be tied at rank 1
+    expect(result.scoreboard[0].rank).toBe(1);
+    expect(result.scoreboard[1].rank).toBe(1);
+  });
+
   it("Value overrides for solves do not count towards dynamic scoring", () => {
     mockEvaluate.mockReturnValue(1);
     const solvesByChallenge = new Map<number, RawSolve[]>([

--- a/core/server-core/src/services/scoreboard/calc.ts
+++ b/core/server-core/src/services/scoreboard/calc.ts
@@ -12,6 +12,7 @@ import { MinimalTeamInfo } from "../../dao/team.ts";
 import { RawSolve } from "../../dao/submission.ts";
 import { HistoryDataPoint } from "../../dao/score_history.ts";
 import { IsTimeBetweenSeconds } from "../../util/time.ts";
+import { topK } from "../../util/arrays.ts";
 
 export type ChallengeMetadataWithExpr = {
   expr: Expression;
@@ -95,21 +96,21 @@ function ComputeScoresForChallenge(
     last_event = MaxDate(last_event, s.updated_at);
     return {
       ...s,
+      created_at_ms: s.created_at.getTime(),
       baseScore: s.value !== null ? s.value : memo(n, s.weight),
     };
   });
 
   const bonusMap = new Map<number, number>();
   if (bonus && bonus.length > 0) {
-    const eligible = withBase
-      .filter((s) => s.value === null)
-      .sort(
-        (a, b) =>
-          b.baseScore - a.baseScore ||
-          a.created_at.getTime() - b.created_at.getTime(),
-      );
+    const eligible = withBase.filter((s) => s.value === null);
+    const topEligible = topK(
+      eligible,
+      bonus.length,
+      (a, b) => b.baseScore - a.baseScore || a.created_at_ms - b.created_at_ms,
+    );
 
-    eligible.forEach((item, rank) => {
+    topEligible.forEach((item, rank) => {
       if (bonus[rank] !== undefined) {
         bonusMap.set(item.team_id, bonus[rank]);
       }
@@ -168,29 +169,58 @@ function ComputeScoreStreamForChallenge(
   );
 
   const memo = MemoizeScore(expr, params);
-  const stream: { team_id: number; delta: number; updated_at: Date }[] = [];
+  const stream: {
+    team_id: number;
+    delta: number;
+    updated_at: Date;
+    updated_at_ms: number;
+  }[] = [];
   const teamScores = new Map<number, { score: number; w: number }>();
+  const distinctWeights = new Set<number>();
   let bonusIdx = 0;
   let n = 0;
   valid.forEach(({ team_id, created_at, value, weight }) => {
+    const updated_at_ms = created_at.getTime();
     const b = value !== null ? undefined : bonus?.[bonusIdx++];
     if (value === null) {
       n++;
-      // n changed: emit retroactive score adjustments for all previous solvers
-      for (const [tid, state] of teamScores) {
-        const updated = memo(n, state.w);
-        const delta = updated - state.score;
-        if (delta !== 0) {
-          stream.push({ team_id: tid, delta, updated_at: created_at });
-          state.score = updated;
+      // Check if any distinct weight produces a non-zero delta
+      let anyChanged = false;
+      for (const w of distinctWeights) {
+        if (memo(n, w) !== memo(n - 1, w)) {
+          anyChanged = true;
+          break;
+        }
+      }
+
+      if (anyChanged) {
+        // n changed: emit retroactive score adjustments for previous solvers whose score changed
+        for (const [tid, state] of teamScores) {
+          const updated = memo(n, state.w);
+          const delta = updated - state.score;
+          if (delta !== 0) {
+            stream.push({
+              team_id: tid,
+              delta,
+              updated_at: created_at,
+              updated_at_ms,
+            });
+            state.score = updated;
+          }
         }
       }
     }
     const score =
       value !== null ? value : memo(n, weight) + ((b && Math.round(b)) || 0);
-    stream.push({ team_id, delta: score, updated_at: created_at });
+    stream.push({
+      team_id,
+      delta: score,
+      updated_at: created_at,
+      updated_at_ms,
+    });
     // Only track dynamic solves for future retroactive adjustments
     if (value === null) {
+      distinctWeights.add(weight);
       teamScores.set(team_id, { score: memo(n, weight), w: weight });
     }
   });
@@ -218,22 +248,20 @@ export function ComputeFullGraph(
       team_id,
       delta: value,
       updated_at: created_at,
+      updated_at_ms: created_at.getTime(),
     });
   }
-  stream.sort((a, b) => {
-    const t = a.team_id - b.team_id;
-    if (t !== 0) return t;
-    return a.updated_at.getTime() - b.updated_at.getTime();
-  });
+  stream.sort(
+    (a, b) => a.team_id - b.team_id || a.updated_at_ms - b.updated_at_ms,
+  );
   const scores = new Map<number, number>();
   const points: HistoryDataPoint[] = [];
   let lastUpdated: number | undefined;
-  for (const { team_id, delta, updated_at } of stream) {
+  for (const { team_id, delta, updated_at_ms } of stream) {
     const score = (scores.get(team_id) || 0) + delta;
     scores.set(team_id, score);
     const last = points[points.length - 1];
-    const sampled =
-      Math.floor(updated_at.getTime() / sampleRateMs) * sampleRateMs;
+    const sampled = Math.floor(updated_at_ms / sampleRateMs) * sampleRateMs;
     if (last && last.team_id === team_id && lastUpdated === sampled) {
       last.score = score;
     } else {
@@ -334,13 +362,15 @@ export function ComputeScoreboard(
 
   const sorted = scoreboard.sort(
     (a, b) =>
-      b.score - a.score || a.last_solve.getTime() - b.last_solve.getTime(),
+      b.score - a.score ||
+      a.last_solve.getTime() - b.last_solve.getTime() ||
+      a.team_id - b.team_id, // this should never happen but used to preserve stability
   );
   sorted.forEach((x, i) => {
     x.rank =
       i > 0 &&
       sorted[i - 1].score === x.score &&
-      sorted[i - 1].last_solve === x.last_solve
+      sorted[i - 1].last_solve.getTime() === x.last_solve.getTime()
         ? i
         : i + 1;
     x.hidden =

--- a/core/server-core/src/util/arrays.test.ts
+++ b/core/server-core/src/util/arrays.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { bisectLeft, bisectRight, insort } from "./arrays.ts";
+import { bisectLeft, bisectRight, insort, topK } from "./arrays.ts";
 
 describe("bisectLeft", () => {
   it("should find the leftmost insertion point in a simple array", () => {
@@ -134,5 +134,41 @@ describe("insort", () => {
     const arr = [1, 2, 2, 2, 5];
     const newArr = insort(arr, 2);
     expect(newArr).toEqual([1, 2, 2, 2, 2, 5]);
+  });
+});
+
+describe("topK", () => {
+  const numCmp = (a: number, b: number) => a - b; // ascending
+
+  it("should return empty array when k <= 0 or arr is empty", () => {
+    expect(topK([], 3, numCmp)).toEqual([]);
+    expect(topK([1, 2, 3], 0, numCmp)).toEqual([]);
+    expect(topK([1, 2, 3], -1, numCmp)).toEqual([]);
+  });
+
+  it("should return sorted array if arr.length <= k", () => {
+    expect(topK([5, 2, 8], 5, numCmp)).toEqual([2, 5, 8]);
+    expect(topK([5, 2, 8], 3, numCmp)).toEqual([2, 5, 8]);
+  });
+
+  it("should return top k smallest elements when arr.length > k", () => {
+    const arr = [10, 3, 5, 1, 9, 2, 8, 4, 7, 6];
+    expect(topK(arr, 3, numCmp)).toEqual([1, 2, 3]);
+  });
+
+  it("should work with custom objects and descending comparator", () => {
+    const items = [
+      { id: 1, score: 100, time: 10 },
+      { id: 2, score: 200, time: 20 },
+      { id: 3, score: 200, time: 15 },
+      { id: 4, score: 50, time: 5 },
+      { id: 5, score: 150, time: 12 },
+    ];
+    // Higher score first, then earlier time
+    const cmp = (a: (typeof items)[0], b: (typeof items)[0]) =>
+      b.score - a.score || a.time - b.time;
+
+    const top3 = topK(items, 3, cmp);
+    expect(top3.map((x) => x.id)).toEqual([3, 2, 5]);
   });
 });

--- a/core/server-core/src/util/arrays.ts
+++ b/core/server-core/src/util/arrays.ts
@@ -67,3 +67,30 @@ export function insort<T, V>(
   const index = bisectRight(arr, getter(item), getter);
   return [...arr.slice(0, index), item, ...arr.slice(index)];
 }
+
+/**
+ * Returns the top K elements from an array according to a comparator function.
+ * Avoids full O(N log N) sorting when K is much smaller than N.
+ * @param arr - The array to extract top K elements from
+ * @param k - The maximum number of elements to return
+ * @param cmp - Comparator function where cmp(a, b) < 0 means 'a' ranks before 'b'
+ * @returns Array of at most K elements sorted by cmp
+ */
+export function topK<T>(arr: T[], k: number, cmp: (a: T, b: T) => number): T[] {
+  if (k <= 0) return [];
+  if (arr.length <= k) return arr.slice().sort(cmp);
+
+  const top = arr.slice(0, k).sort(cmp);
+  for (let i = k; i < arr.length; i++) {
+    const item = arr[i]!;
+    if (cmp(item, top[k - 1]!) < 0) {
+      let j = k - 1;
+      while (j > 0 && cmp(item, top[j - 1]!) < 0) {
+        top[j] = top[j - 1]!;
+        j--;
+      }
+      top[j] = item;
+    }
+  }
+  return top;
+}


### PR DESCRIPTION
### Summary
Optimises hot paths in scoreboard calculation (`calc.ts`) and fixes a tie-breaking rank bug on equal solve timestamps.

### Changes
-  Added `topK` sliding-window utility in `arrays.ts` to select top bonus solves in `O(N)` 
- Pre-extracted epoch milliseconds (`created_at_ms`, `updated_at_ms`) across solves and stream points, avoiding redundant `.getTime()` calls inside sorting comparators.
- Grouped decay adjustments by distinct weights in `ComputeScoreStreamForChallenge`. Skips the team loop on zero-delta ticks and evaluates formulas once per weight instead of once per solver.
- Replaced `last_solve === last_solve` (which failed on separate `Date` instances) with `.getTime() === .getTime()` so teams with identical scores and timestamps properly tie.

### Tests
- Added unit tests for `topK` covering boundary conditions and ties.
- Added regression test for tied ranks with identical solve timestamps.
